### PR TITLE
Add time-based eviction to caches for BigQuery resources

### DIFF
--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryReference.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryReference.java
@@ -24,6 +24,7 @@ import com.google.zetasql.toolkit.catalog.bigquery.exceptions.InvalidBigQueryRef
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /** Dataclass representing a reference to a BigQuery resource. */
@@ -117,5 +118,26 @@ class BigQueryReference {
 
   public RoutineId toRoutineId() {
     return RoutineId.of(this.getProjectId(), this.getDatasetId(), this.getResourceName());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof BigQueryReference)) {
+      return false;
+    }
+
+    BigQueryReference that = (BigQueryReference) o;
+    return Objects.equals(projectId, that.projectId)
+        && Objects.equals(datasetId, that.datasetId)
+        && Objects.equals(resourceName, that.resourceName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(projectId, datasetId, resourceName);
   }
 }

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/exceptions/BigQueryAPIError.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/exceptions/BigQueryAPIError.java
@@ -16,11 +16,9 @@
 
 package com.google.zetasql.toolkit.catalog.bigquery.exceptions;
 
-import com.google.cloud.bigquery.BigQueryException;
-
 public class BigQueryAPIError extends BigQueryCatalogException {
 
-  public BigQueryAPIError(String message, BigQueryException cause) {
+  public BigQueryAPIError(String message, Throwable cause) {
     super(message, cause);
   }
 }


### PR DESCRIPTION
Adds time-based eviction for the caching of BigQuery resources on the `BigQueryService` class. Uses the Guava `Cache` class.