### PR TITLE
Release v0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This toolkit offers built-in support for:
   <groupId>com.google.zetasql.toolkit</groupId>
   <artifactId>zetasql-toolkit-core</artifactId>
   <scope>compile</scope>
-  <version>0.3.1</version>
+  <version>0.3.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit</artifactId>
-    <version>0.3.2</version>
+    <version>0.3.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>
         <url>https://github.com/GoogleCloudPlatform/zetasql-toolkit</url>
         <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/zetasql-toolkit.git</developerConnection>
-      <tag>v0.3.2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
     <packaging>pom</packaging>
 
     <scm>
         <url>https://github.com/GoogleCloudPlatform/zetasql-toolkit</url>
         <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/zetasql-toolkit.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>v0.3.2</tag>
   </scm>
 
     <properties>

--- a/zetasql-toolkit-core/pom.xml
+++ b/zetasql-toolkit-core/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.3.2</version>
+    <version>0.3.3-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/GoogleCloudPlatform/zetasql-toolkit</url>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</connection>
         <developerConnection>scm:git:git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</developerConnection>
         <url>git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</url>
-      <tag>v0.3.2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/zetasql-toolkit-core/pom.xml
+++ b/zetasql-toolkit-core/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/GoogleCloudPlatform/zetasql-toolkit</url>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</connection>
         <developerConnection>scm:git:git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</developerConnection>
         <url>git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</url>
-      <tag>HEAD</tag>
+      <tag>v0.3.2</tag>
   </scm>
 
     <properties>

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
@@ -34,6 +34,7 @@ import com.google.zetasql.toolkit.catalog.exceptions.CatalogResourceAlreadyExist
 import com.google.zetasql.toolkit.catalog.spanner.exceptions.InvalidSpannerTableName;
 import com.google.zetasql.toolkit.options.SpannerLanguageOptions;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -212,8 +213,12 @@ public class SpannerCatalog implements CatalogWrapper {
   public void addTables(List<String> tableNames) {
     this.validateSpannerTableNames(tableNames);
 
+    List<String> tablesNotInCatalog = tableNames.stream()
+        .filter(tableName -> Objects.isNull(this.catalog.getTable(tableName, null)))
+        .collect(Collectors.toList());
+
     this.spannerResourceProvider
-        .getTables(tableNames)
+        .getTables(tablesNotInCatalog)
         .forEach(
             table ->
                 this.register(

--- a/zetasql-toolkit-examples/pom.xml
+++ b/zetasql-toolkit-examples/pom.xml
@@ -21,13 +21,13 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-examples</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.3.2-SNAPSHOT</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.3.2</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.2</google.cloud.jib.version>
         <container.mainClass />
     </properties>

--- a/zetasql-toolkit-examples/pom.xml
+++ b/zetasql-toolkit-examples/pom.xml
@@ -21,13 +21,13 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-examples</artifactId>
-    <version>0.3.2</version>
+    <version>0.3.3-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.3.2</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.3.3-SNAPSHOT</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.2</google.cloud.jib.version>
         <container.mainClass />
     </properties>


### PR DESCRIPTION
Release version 0.3.2 of the ZetaSQL Toolkit

Changelog:
* `add` methods in the `BigQueryCatalog` and the `SpannerCatalog` now ignore resources that have already been added to said catalog