### PR TITLE
Release v0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ This toolkit offers built-in support for:
 <dependency>
   <groupId>com.google.zetasql.toolkit</groupId>
   <artifactId>zetasql-toolkit-core</artifactId>
-  <scope>compile</scope>
-  <version>0.3.2</version>
+  <version>0.3.3</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.3</version>
     <packaging>pom</packaging>
 
     <scm>
         <url>https://github.com/GoogleCloudPlatform/zetasql-toolkit</url>
         <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/zetasql-toolkit.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>v0.3.3</tag>
   </scm>
 
     <properties>

--- a/zetasql-toolkit-core/pom.xml
+++ b/zetasql-toolkit-core/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.3</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/GoogleCloudPlatform/zetasql-toolkit</url>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</connection>
         <developerConnection>scm:git:git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</developerConnection>
         <url>git@github.com:GoogleCloudPlatform/zetasql-toolkit.git</url>
-      <tag>HEAD</tag>
+      <tag>v0.3.3</tag>
   </scm>
 
     <properties>

--- a/zetasql-toolkit-examples/pom.xml
+++ b/zetasql-toolkit-examples/pom.xml
@@ -21,13 +21,13 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-examples</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.3</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.3.3-SNAPSHOT</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.3.3</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.2</google.cloud.jib.version>
         <container.mainClass />
     </properties>


### PR DESCRIPTION
Release version 0.3.3 of the ZetaSQL Toolkit

Changelog:

* Support bigquery resources with dashes (-) in their names: #9 