### PR TITLE
Add support for analyzing variable declarations and assignments

### DIFF
--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
@@ -439,6 +439,33 @@ public class BigQueryCatalog implements CatalogWrapper {
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if the constant name is qualified
+   * @throws CatalogResourceAlreadyExists if the constant already exits in this catalog
+   */
+  @Override
+  public void register(Constant constant) {
+    String fullName = constant.getFullName();
+
+    if (constant.getNamePath().size() > 1) {
+      throw new IllegalArgumentException(
+          "BigQuery constants cannot be qualified, was: " + fullName);
+    }
+
+    boolean constantExists = this.catalog.getConstantList()
+        .stream()
+        .anyMatch(existingConstant -> existingConstant.getFullName().equalsIgnoreCase(fullName));
+
+    if (constantExists) {
+      throw new CatalogResourceAlreadyExists(
+          fullName, "Constant " + fullName + "already exists");
+    }
+
+    this.catalog.addConstant(constant);
+  }
+
   @Override
   public void removeTable(String tableReference) {
     boolean isQualified = tableReference.split("\\.").length > 1;

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
@@ -818,6 +818,25 @@ public class BigQueryCatalog implements CatalogWrapper {
     this.addProcedures(List.copyOf(procedures));
   }
 
+  /**
+   * Adds all the resources used in the provided query to this catalog. Includes tables, functions,
+   * TVFs and procedures.
+   *
+   * <p> It calls {@link #addAllTablesUsedInQuery(String, AnalyzerOptions)},
+   * {@link #addAllFunctionsUsedInQuery(String)}, {@link #addAllTVFsUsedInQuery(String)}
+   * and {@link #addAllProceduresUsedInQuery(String)}.
+   *
+   * @param query The SQL query from which to get the resources that should be added to the catalog
+   * @param options The ZetaSQL AnalyzerOptions to use when extracting the resource names from the
+   *     query
+   */
+  public void addAllResourcesUsedInQuery(String query, AnalyzerOptions options) {
+    addAllTablesUsedInQuery(query, options);
+    addAllFunctionsUsedInQuery(query);
+    addAllTVFsUsedInQuery(query);
+    addAllProceduresUsedInQuery(query);
+  }
+
   @Override
   public BigQueryCatalog copy() {
     return new BigQueryCatalog(

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalysisException.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalysisException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.zetasql.toolkit;
 
 import com.google.zetasql.SqlException;

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalysisException.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalysisException.java
@@ -1,0 +1,18 @@
+package com.google.zetasql.toolkit;
+
+import com.google.zetasql.SqlException;
+
+/**
+ * Exception thrown by the {@link ZetaSQLToolkitAnalyzer} when analysis fails.
+ */
+public class AnalysisException extends RuntimeException {
+
+  public AnalysisException(String message) {
+    super(message);
+  }
+
+  public AnalysisException(SqlException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+}

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalyzedStatement.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalyzedStatement.java
@@ -25,14 +25,10 @@ public class AnalyzedStatement {
   private final ASTStatement parsedStatement;
   private final Optional<ResolvedStatement> resolvedStatement;
 
-  public AnalyzedStatement(ASTStatement parsedStatement) {
+  public AnalyzedStatement(
+      ASTStatement parsedStatement, Optional<ResolvedStatement> resolvedStatement) {
     this.parsedStatement = parsedStatement;
-    this.resolvedStatement = Optional.empty();
-  }
-
-  public AnalyzedStatement(ASTStatement parsedStatement, ResolvedStatement resolvedStatement) {
-    this.parsedStatement = parsedStatement;
-    this.resolvedStatement = Optional.of(resolvedStatement);
+    this.resolvedStatement = resolvedStatement;
   }
 
   public ASTStatement getParsedStatement() {

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalyzedStatement.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalyzedStatement.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit;
+
+import com.google.zetasql.parser.ASTNodes.ASTStatement;
+import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
+import java.util.Optional;
+
+public class AnalyzedStatement {
+
+  private final ASTStatement parsedStatement;
+  private final Optional<ResolvedStatement> resolvedStatement;
+
+  public AnalyzedStatement(ASTStatement parsedStatement) {
+    this.parsedStatement = parsedStatement;
+    this.resolvedStatement = Optional.empty();
+  }
+
+  public AnalyzedStatement(ASTStatement parsedStatement, ResolvedStatement resolvedStatement) {
+    this.parsedStatement = parsedStatement;
+    this.resolvedStatement = Optional.of(resolvedStatement);
+  }
+
+  public ASTStatement getParsedStatement() {
+    return parsedStatement;
+  }
+
+  public Optional<ResolvedStatement> getResolvedStatement() {
+    return resolvedStatement;
+  }
+
+}

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/Coercer.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/Coercer.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit;
+
+import com.google.common.collect.ImmutableList;
+import com.google.zetasql.ArrayType;
+import com.google.zetasql.LanguageOptions;
+import com.google.zetasql.StructType;
+import com.google.zetasql.Type;
+import com.google.zetasql.ZetaSQLOptions.LanguageFeature;
+import com.google.zetasql.ZetaSQLType.TypeKind;
+import java.util.Optional;
+
+/**
+ * Basic (and not complete) implementation of a type coercer for ZetaSQL, based on the
+ * <a href="https://github.com/google/zetasql/blob/master/zetasql/public/coercer.cc">C++ Coercer</a>
+ *
+ * <p> This is not a complete implementation for ZetaSQL; since it doesn't properly implement
+ * coercion for protos, enums and other complex types. However, it should suffice for the
+ * SQL engines the ZetaSQL toolkit is targeting (primarily BigQuery and Cloud Spanner).
+ */
+class Coercer {
+
+  private final LanguageOptions languageOptions;
+
+  public Coercer(LanguageOptions languageOptions) {
+    this.languageOptions = languageOptions;
+  }
+
+  /**
+   * List of supported type coercions in ZetaSQL.
+   *
+   * <p> Each {@link TypeCoercion} specifies a supported type coercion from one type
+   * (the "from" type) to another (the "to" type). Each coercion has a {@link CoercionMode}
+   * associated to it.
+   *
+   * <p> For example:
+   *
+   * <ul>
+   *   <li> BOOL implicitly coerces to BOOL (any type coerces implicitly to itself)
+   *   <li> INT32 implicitly coerces to INT64 and DOUBLE
+   *   <li> INT32 explicitly coerces to STRING (it needs to be casted)
+   * </ul>
+   */
+  private static final ImmutableList<TypeCoercion> supportedTypeCoercions = ImmutableList.of(
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BOOL, /*to=*/TypeKind.TYPE_BOOL, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BOOL, /*to=*/TypeKind.TYPE_INT32, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BOOL, /*to=*/TypeKind.TYPE_INT64, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BOOL, /*to=*/TypeKind.TYPE_UINT32, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BOOL, /*to=*/TypeKind.TYPE_UINT64, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BOOL, /*to=*/TypeKind.TYPE_STRING, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_BOOL, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_INT32, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_INT64, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_FLOAT,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_ENUM,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT32, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_BOOL, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_INT32,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_INT64, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_FLOAT,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_ENUM,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INT64, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_BOOL, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_INT32,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_INT64,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_FLOAT,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_ENUM,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT32, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_BOOL, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_INT32,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_INT64,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_FLOAT,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_ENUM,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_UINT64, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_INT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_INT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_FLOAT,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_NUMERIC, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_INT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_INT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_FLOAT,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BIGNUMERIC, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_INT32, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_INT64, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_FLOAT, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_FLOAT, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_INT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_INT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_FLOAT,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DOUBLE, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.EXPLICIT_OR_LITERAL),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_INT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_INT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_UINT32,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_UINT64,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_FLOAT,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_DOUBLE,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_BYTES,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_DATE,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_TIMESTAMP,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_TIME,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_DATETIME,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_INTERVAL,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_ENUM,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_PROTO,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_BOOL, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_NUMERIC,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_BIGNUMERIC,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_STRING, /*to=*/TypeKind.TYPE_RANGE,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BYTES, /*to=*/TypeKind.TYPE_BYTES, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BYTES, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_BYTES, /*to=*/TypeKind.TYPE_PROTO,
+          CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATE, /*to=*/TypeKind.TYPE_DATE, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATE, /*to=*/TypeKind.TYPE_DATETIME,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATE, /*to=*/TypeKind.TYPE_TIMESTAMP,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATE, /*to=*/TypeKind.TYPE_STRING, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_TIMESTAMP, /*to=*/TypeKind.TYPE_DATE,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_TIMESTAMP, /*to=*/TypeKind.TYPE_DATETIME,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_TIMESTAMP, /*to=*/TypeKind.TYPE_TIME,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_TIMESTAMP, /*to=*/TypeKind.TYPE_TIMESTAMP,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_TIMESTAMP, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_TIME, /*to=*/TypeKind.TYPE_TIME, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_TIME, /*to=*/TypeKind.TYPE_STRING, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATETIME, /*to=*/TypeKind.TYPE_DATE,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATETIME, /*to=*/TypeKind.TYPE_DATETIME,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATETIME, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATETIME, /*to=*/TypeKind.TYPE_TIME,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_DATETIME, /*to=*/TypeKind.TYPE_TIMESTAMP,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INTERVAL, /*to=*/TypeKind.TYPE_INTERVAL,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_INTERVAL, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_GEOGRAPHY, /*to=*/TypeKind.TYPE_GEOGRAPHY,
+          CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_JSON, /*to=*/TypeKind.TYPE_JSON, CoercionMode.IMPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_ENUM, /*to=*/TypeKind.TYPE_STRING, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_ENUM, /*to=*/TypeKind.TYPE_INT32, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_ENUM, /*to=*/TypeKind.TYPE_INT64, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_ENUM, /*to=*/TypeKind.TYPE_UINT32, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_ENUM, /*to=*/TypeKind.TYPE_UINT64, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_PROTO, /*to=*/TypeKind.TYPE_STRING,
+          CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_PROTO, /*to=*/TypeKind.TYPE_BYTES, CoercionMode.EXPLICIT),
+      new TypeCoercion(/*from=*/TypeKind.TYPE_RANGE, /*to=*/TypeKind.TYPE_STRING, CoercionMode.EXPLICIT)
+  );
+
+  private enum CoercionMode {
+    IMPLICIT,
+    EXPLICIT,
+    EXPLICIT_OR_LITERAL,
+    EXPLICIT_OR_LITERAL_OR_PARAMETER;
+  }
+
+  private static class TypeCoercion {
+
+    public final TypeKind fromKind;
+    public final TypeKind toKind;
+    public final CoercionMode coercionMode;
+
+    public TypeCoercion(TypeKind fromKind, TypeKind toKind, CoercionMode coercionMode) {
+      this.fromKind = fromKind;
+      this.toKind = toKind;
+      this.coercionMode = coercionMode;
+    }
+  }
+
+  /**
+   * Returns whether fromType can coerce to toType
+   * 
+   * @param fromType The type to coerce from
+   * @param toType The type to coerce to
+   * @param isLiteral Whether the expression that's being coerced is a literal
+   * @param isParameter Whether the expression that's being coerced is a parameter
+   *
+   * @return Whether fromType can coerce to toType
+   */
+  public boolean coercesTo(
+      Type fromType, Type toType,
+      boolean isLiteral, boolean isParameter
+  ) {
+    if (fromType.isStruct()) {
+      return structCoercesTo((StructType) fromType, toType, isLiteral, isParameter);
+    }
+
+    if (fromType.isArray()) {
+      return arrayCoercesTo((ArrayType) fromType, toType, isLiteral, isParameter);
+    }
+
+    if (!fromType.isSimpleType() && !toType.isSimpleType()) {
+      return fromType.equivalent(toType);
+    }
+
+    TypeKind fromKind = fromType.getKind();
+    TypeKind toKind = toType.getKind();
+
+    Optional<CoercionMode> maybeCoercionMode = supportedTypeCoercions.stream()
+        .filter(typeCoercion ->
+            typeCoercion.fromKind.equals(fromKind) && typeCoercion.toKind.equals(toKind))
+        .map(typeCoercion -> typeCoercion.coercionMode)
+        .findFirst();
+
+    if(maybeCoercionMode.isEmpty()) {
+      return false;
+    }
+
+    CoercionMode coercionMode = maybeCoercionMode.get();
+
+    if (isLiteral && supportsLiteralCoercion(coercionMode)) {
+      return true;
+    }
+
+    if (isParameter && supportsParameterCoercion(coercionMode)) {
+      return true;
+    }
+
+    return supportsImplicitCoercion(coercionMode);
+  }
+
+  /**
+   * @see Coercer#coercesTo(Type, Type, boolean, boolean)
+   */
+  public boolean structCoercesTo(
+      StructType fromType, Type toType,
+      boolean isLiteral, boolean isParameter
+  ) {
+    if (!toType.isStruct() || toType.asStruct().getFieldCount() != fromType.getFieldCount()) {
+      return false;
+    }
+
+    StructType toTypeAsStruct = toType.asStruct();
+
+    for (int i = 0; i < fromType.getFieldCount(); i++) {
+      Type fromTypeFieldType = fromType.getField(i).getType();
+      Type toTypeFieldType = toTypeAsStruct.getField(i).getType();
+      if (!coercesTo(fromTypeFieldType, toTypeFieldType, isLiteral, isParameter)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * @see Coercer#coercesTo(Type, Type, boolean, boolean)
+   */
+  public boolean arrayCoercesTo(
+      ArrayType fromType, Type toType,
+      boolean isLiteral, boolean isParameter
+  ) {
+    if (fromType.equivalent(toType)) {
+      return true;
+    }
+
+    if (!languageOptions.languageFeatureEnabled(
+        LanguageFeature.FEATURE_V_1_1_CAST_DIFFERENT_ARRAY_TYPES)) {
+      return false;
+    }
+
+    if (!toType.isArray()) {
+      return false;
+    }
+
+    if (isLiteral || isParameter) {
+      return coercesTo(
+          fromType.getElementType(),
+          toType.asArray().getElementType(),
+          isLiteral,
+          isParameter);
+    }
+
+    return false;
+  }
+
+  public boolean supportsImplicitCoercion(CoercionMode mode) {
+    return mode.equals(CoercionMode.IMPLICIT);
+  }
+
+  public boolean supportsLiteralCoercion(CoercionMode mode) {
+    return mode.equals(CoercionMode.IMPLICIT)
+        || mode.equals(CoercionMode.EXPLICIT_OR_LITERAL)
+        || mode.equals(CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER);
+  }
+
+  public boolean supportsParameterCoercion(CoercionMode mode) {
+    return mode.equals(CoercionMode.IMPLICIT)
+        || mode.equals(CoercionMode.EXPLICIT_OR_LITERAL_OR_PARAMETER);
+  }
+
+}

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ZetaSQLToolkitAnalyzer.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ZetaSQLToolkitAnalyzer.java
@@ -45,7 +45,6 @@ import com.google.zetasql.toolkit.catalog.typeparser.ZetaSQLTypeParser;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Primary class exposed by the ZetaSQL Toolkit to perform SQL analysis.
@@ -295,15 +294,12 @@ public class ZetaSQLToolkitAnalyzer {
 
       Type variableType = explicitType.orElseGet(() -> defaultValueExpr.get().getType());
 
-      List<Constant> constants = declaration.getVariableList()
+      declaration.getVariableList()
           .getIdentifierList()
           .stream()
           .map(ASTIdentifier::getIdString)
           .map(variableName -> this.buildConstant(variableName, variableType))
-          .collect(Collectors.toList());
-
-      // TODO: Add constants to the catalog without breaking encapsulation
-      constants.forEach(catalog.getZetaSQLCatalog()::addConstant);
+          .forEach(catalog::register);
     }
 
     private void validateSingleAssignment(ASTSingleAssignment singleAssignment) {

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/CatalogWrapper.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/CatalogWrapper.java
@@ -16,6 +16,7 @@
 
 package com.google.zetasql.toolkit.catalog;
 
+import com.google.zetasql.Constant;
 import com.google.zetasql.SimpleCatalog;
 import com.google.zetasql.SimpleTable;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateMode;
@@ -67,30 +68,37 @@ public interface CatalogWrapper {
   void register(ProcedureInfo procedureInfo, CreateMode createMode, CreateScope createScope);
 
   /**
+   * Registers a constant in this catalog.
+   *
+   * @param constant The {@link Constant} object representing the constant to register
+   */
+  void register(Constant constant);
+
+  /**
    * Removes a table to this catalog by name.
    *
-   * @param table The reference to the table to add
+   * @param table The reference to the table to remove
    */
   void removeTable(String table);
 
   /**
    * Removes a function to this catalog by name.
    *
-   * @param function The reference to the function to add
+   * @param function The reference to the function to remove
    */
   void removeFunction(String function);
 
   /**
    * Removes a TVF to this catalog by name.
    *
-   * @param function The reference to the TVF to add
+   * @param function The reference to the TVF to remove
    */
   void removeTVF(String function);
 
   /**
    * Removes a procedure to this catalog by name.
    *
-   * @param procedure The reference to the procedure to add
+   * @param procedure The reference to the procedure to remove
    */
   void removeProcedure(String procedure);
 
@@ -108,7 +116,7 @@ public interface CatalogWrapper {
   /**
    * Removes a set of functions to this catalog by name.
    *
-   * @param functions The list of function references to add
+   * @param functions The list of function references to remove
    */
   default void removeFunctions(List<String> functions) {
     for (String function : functions) {
@@ -119,7 +127,7 @@ public interface CatalogWrapper {
   /**
    * Removes a set of TVFs to this catalog by name.
    *
-   * @param functions The list of function references to add
+   * @param functions The list of function references to remove
    */
   default void removeTVFs(List<String> functions) {
     for (String function : functions) {
@@ -130,7 +138,7 @@ public interface CatalogWrapper {
   /**
    * Removes a set of procedures to this catalog by name.
    *
-   * @param procedures The list of procedure references to add
+   * @param procedures The list of procedure references to remove
    */
   default void removeProcedures(List<String> procedures) {
     for (String procedure : procedures) {

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/basic/BasicCatalogWrapper.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/basic/BasicCatalogWrapper.java
@@ -16,6 +16,7 @@
 
 package com.google.zetasql.toolkit.catalog.basic;
 
+import com.google.zetasql.Constant;
 import com.google.zetasql.SimpleCatalog;
 import com.google.zetasql.SimpleTable;
 import com.google.zetasql.ZetaSQLBuiltinFunctionOptions;
@@ -27,6 +28,7 @@ import com.google.zetasql.toolkit.catalog.FunctionInfo;
 import com.google.zetasql.toolkit.catalog.ProcedureInfo;
 import com.google.zetasql.toolkit.catalog.TVFInfo;
 import com.google.zetasql.toolkit.catalog.exceptions.CatalogException;
+import com.google.zetasql.toolkit.catalog.exceptions.CatalogResourceAlreadyExists;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -102,6 +104,27 @@ public class BasicCatalogWrapper implements CatalogWrapper {
 
     CatalogOperations.createProcedureInCatalog(
         this.catalog, procedurePaths, procedureInfo, createMode);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws CatalogResourceAlreadyExists if the constant already exits in this catalog
+   */
+  @Override
+  public void register(Constant constant) {
+    String fullName = constant.getFullName();
+
+    boolean constantExists = this.catalog.getConstantList()
+        .stream()
+        .anyMatch(existingConstant -> existingConstant.getFullName().equalsIgnoreCase(fullName));
+
+    if (constantExists) {
+      throw new CatalogResourceAlreadyExists(
+          fullName, "Constant " + fullName + "already exists");
+    }
+
+    this.catalog.addConstant(constant);
   }
 
   @Override

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/typeparser/ZetaSQLTypeParser.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/typeparser/ZetaSQLTypeParser.java
@@ -80,7 +80,7 @@ public class ZetaSQLTypeParser {
             Map.entry("INT64", TypeKind.TYPE_INT64),
             Map.entry("UINT32", TypeKind.TYPE_UINT32),
             Map.entry("UINT64", TypeKind.TYPE_UINT64),
-            Map.entry("FLOAT64", TypeKind.TYPE_FLOAT),
+            Map.entry("FLOAT64", TypeKind.TYPE_DOUBLE),
             Map.entry("DECIMAL", TypeKind.TYPE_NUMERIC),
             Map.entry("NUMERIC", TypeKind.TYPE_NUMERIC),
             Map.entry("BIGNUMERIC", TypeKind.TYPE_BIGNUMERIC),

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/typeparser/ZetaSQLTypeParser.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/typeparser/ZetaSQLTypeParser.java
@@ -25,10 +25,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ConsoleErrorListener;
 import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 /**
@@ -56,15 +58,24 @@ public class ZetaSQLTypeParser {
     ZetaSQLTypeGrammarParser parser = new ZetaSQLTypeGrammarParser(tokenStream);
     ZetaSQLTypeParserListener listener = new ZetaSQLTypeParserListener();
     parser.removeErrorListener(ConsoleErrorListener.INSTANCE);
-    TypeContext typeRule = parser.type();
-    ParseTreeWalker.DEFAULT.walk(listener, typeRule);
+    parser.setErrorHandler(new BailErrorStrategy());
 
-    if (typeRule.exception != null) {
+    try {
+      TypeContext typeRule = parser.type();
+
+      if (typeRule.exception != null) {
+        throw new ZetaSQLTypeParseError(
+            String.format("Invalid SQL type: %s", type), typeRule.exception);
+      }
+
+      ParseTreeWalker.DEFAULT.walk(listener, typeRule);
+
+      return listener.getResult();
+    } catch (ParseCancellationException err) {
       throw new ZetaSQLTypeParseError(
-          String.format("Invalid SQL type: %s", type), typeRule.exception);
+          String.format("Invalid SQL type: %s", type), err);
     }
 
-    return listener.getResult();
   }
 
   /**
@@ -129,6 +140,10 @@ public class ZetaSQLTypeParser {
 
     @Override
     public void exitStructType(StructTypeContext ctx) {
+      if (this.structFieldStack.empty()) {
+        return;
+      }
+
       List<StructField> fields = this.structFieldStack.pop();
       Type type = TypeFactory.createStructType(fields);
       this.typeStack.push(type);

--- a/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/CoercerTest.java
+++ b/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/CoercerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.zetasql.LanguageOptions;
+import com.google.zetasql.StructType.StructField;
+import com.google.zetasql.Type;
+import com.google.zetasql.TypeFactory;
+import com.google.zetasql.ZetaSQLOptions.LanguageFeature;
+import com.google.zetasql.ZetaSQLType.TypeKind;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CoercerTest {
+
+  @Test
+  void testBasicCoercions() {
+    Type int32Type = TypeFactory.createSimpleType(TypeKind.TYPE_INT32);
+    Type int64Type = TypeFactory.createSimpleType(TypeKind.TYPE_INT64);
+    Type doubleType = TypeFactory.createSimpleType(TypeKind.TYPE_DOUBLE);
+    Type stringType = TypeFactory.createSimpleType(TypeKind.TYPE_STRING);
+    Type timestampType = TypeFactory.createSimpleType(TypeKind.TYPE_TIMESTAMP);
+
+    LanguageOptions languageOptions = new LanguageOptions();
+    languageOptions.enableMaximumLanguageFeatures();
+
+    Coercer coercer = new Coercer(languageOptions);
+
+    assertTrue(
+        coercer.coercesTo(int32Type, int64Type, false, false),
+        "Expect INT32 to coerce to INT64");
+    assertTrue(
+        coercer.coercesTo(int32Type, doubleType, false, false),
+        "Expect INT32 to coerce to DOUBLE");
+    assertFalse(
+        coercer.coercesTo(int32Type, stringType, false, false),
+        "Expect INT32 to not coerce to STRING");
+    assertFalse(
+        coercer.coercesTo(int64Type, int32Type, false, false),
+        "Expect INT64 to not coerce to INT32");
+    assertTrue(
+        coercer.coercesTo(int64Type, int32Type, true, false),
+        "Expect INT64 literals to coerce to INT32");
+    assertFalse(
+        coercer.coercesTo(stringType, timestampType, false, false),
+        "Expect STRING to not coerce to TIMESTAMP");
+    assertTrue(
+        coercer.coercesTo(stringType, timestampType, true, false),
+        "Expect STRING literals to coerce to TIMESTAMP");
+    assertTrue(
+        coercer.coercesTo(stringType, timestampType, false, true),
+        "Expect STRING parameters to coerce to TIMESTAMP");
+  }
+
+  @Test
+  void testArrayCoercions() {
+    Type int32Array = TypeFactory.createArrayType(
+        TypeFactory.createSimpleType(TypeKind.TYPE_INT32)
+    );
+    Type int64Array = TypeFactory.createArrayType(
+        TypeFactory.createSimpleType(TypeKind.TYPE_INT64)
+    );
+
+    LanguageOptions languageOptions = new LanguageOptions();
+
+    Coercer coercer = new Coercer(languageOptions);
+
+    assertFalse(
+        coercer.coercesTo(int32Array, int64Array, true, false),
+        "Expect ARRAY<INT32> literal to not coerce to ARRAY<INT64> when "
+            + "FEATURE_V_1_1_CAST_DIFFERENT_ARRAY_TYPES is not enabled");
+
+    languageOptions.enableLanguageFeature(LanguageFeature.FEATURE_V_1_1_CAST_DIFFERENT_ARRAY_TYPES);
+
+    assertTrue(
+        coercer.coercesTo(int32Array, int64Array, true, false),
+        "Expect ARRAY<INT32> literal to coerce to ARRAY<INT64> when "
+            + "FEATURE_V_1_1_CAST_DIFFERENT_ARRAY_TYPES is enabled");
+
+    assertFalse(
+        coercer.coercesTo(int32Array, int64Array, false, false),
+        "Expect non-literal ARRAY<INT32> to not coerce to ARRAY<INT64>");
+  }
+
+  @Test
+  void testStructCoercions() {
+    Type structWithInt32Field = TypeFactory.createStructType(List.of(
+        new StructField("field", TypeFactory.createSimpleType(TypeKind.TYPE_INT32))
+    ));
+    Type structWithInt64Field = TypeFactory.createStructType(List.of(
+        new StructField("field", TypeFactory.createSimpleType(TypeKind.TYPE_INT64))
+    ));
+
+    LanguageOptions languageOptions = new LanguageOptions();
+    languageOptions.enableMaximumLanguageFeatures();
+
+    Coercer coercer = new Coercer(languageOptions);
+
+    assertTrue(
+        coercer.coercesTo(structWithInt32Field, structWithInt64Field, false, false),
+        "Expect compatible STRUCTs to coerce to one another");
+  }
+
+  @Test
+  void testComplexCoercions() {
+    Type int32StructArray = TypeFactory.createArrayType(
+        TypeFactory.createStructType(List.of(
+          new StructField("field", TypeFactory.createSimpleType(TypeKind.TYPE_INT32))
+        ))
+    );
+    Type int64StructArray = TypeFactory.createArrayType(
+        TypeFactory.createStructType(List.of(
+            new StructField("field", TypeFactory.createSimpleType(TypeKind.TYPE_INT64))
+        ))
+    );
+
+    LanguageOptions languageOptions = new LanguageOptions();
+    languageOptions.enableMaximumLanguageFeatures();
+
+    Coercer coercer = new Coercer(languageOptions);
+
+    assertTrue(
+        coercer.coercesTo(int32StructArray, int64StructArray, true, false),
+        "Expect compatible ARRAY<STRUCT<...>> literals to coerce to one another");
+
+  }
+
+}

--- a/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/ZetaSQLToolkitTest.java
+++ b/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/ZetaSQLToolkitTest.java
@@ -19,7 +19,13 @@ package com.google.zetasql.toolkit;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.zetasql.AnalyzerOptions;
+import com.google.zetasql.SimpleCatalog;
+import com.google.zetasql.SimpleTable;
+import com.google.zetasql.parser.ASTNodes.ASTSimpleType;
+import com.google.zetasql.parser.ASTNodes.ASTVariableDeclaration;
 import com.google.zetasql.resolvedast.ResolvedNodes.*;
+import com.google.zetasql.toolkit.catalog.basic.BasicCatalogWrapper;
+import java.util.Iterator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,4 +65,77 @@ public class ZetaSQLToolkitTest {
         assertInstanceOf(ResolvedLiteral.class, projectScan.getExprList().get(0).getExpr());
     assertEquals(1, literal.getValue().getInt64Value());
   }
+
+  @Test
+  void testTableDDL() {
+    String query = "CREATE TEMP TABLE t AS (SELECT 1 AS column);\n"
+        + "SELECT * FROM t;";
+    SimpleCatalog catalog = new SimpleCatalog("catalog");
+
+    Iterator<AnalyzedStatement> statementIterator =
+        this.analyzer.analyzeStatements(query, new BasicCatalogWrapper(catalog), true);
+
+    AnalyzedStatement first = statementIterator.next();
+    assertTrue(first.getResolvedStatement().isPresent());
+    assertInstanceOf(ResolvedCreateTableAsSelectStmt.class, first.getResolvedStatement().get());
+    assertNotNull(catalog.getTable("t", null));
+    SimpleTable table = catalog.getTable("t", null);
+    assertAll(
+        () -> assertEquals("t", table.getName()),
+        () -> assertEquals(1, table.getColumnList().size()),
+        () -> assertEquals("column", table.getColumnList().get(0).getName())
+    );
+
+    // Just check that the second statement was analyzed successfully
+    AnalyzedStatement second = statementIterator.next();
+    assertTrue(second.getResolvedStatement().isPresent());
+    assertInstanceOf(ResolvedQueryStmt.class, second.getResolvedStatement().get());
+  }
+
+  @Test
+  void testVariableDeclaration() {
+    String query = "DECLARE x INT64 DEFAULT 1;\n"
+        + "SELECT x;";
+    SimpleCatalog catalog = new SimpleCatalog("catalog");
+
+    Iterator<AnalyzedStatement> statementIterator =
+        this.analyzer.analyzeStatements(query, new BasicCatalogWrapper(catalog), true);
+
+    AnalyzedStatement first = statementIterator.next();
+    ASTVariableDeclaration variableDeclaration =
+        assertInstanceOf(ASTVariableDeclaration.class, first.getParsedStatement());
+    ASTSimpleType type = assertInstanceOf(ASTSimpleType.class, variableDeclaration.getType());
+    assertEquals("INT64", type.getTypeName().getNames().get(0).getIdString());
+    assertEquals(1, catalog.getConstantList().size());
+    assertEquals("x", catalog.getConstantList().get(0).getFullName());
+    assertTrue(catalog.getConstantList().get(0).getType().isInt64());
+
+    AnalyzedStatement second = statementIterator.next();
+    assertTrue(second.getResolvedStatement().isPresent());
+    ResolvedQueryStmt queryStmt =
+        assertInstanceOf(ResolvedQueryStmt.class, second.getResolvedStatement().get());
+    ResolvedProjectScan projectScan =
+        assertInstanceOf(ResolvedProjectScan.class, queryStmt.getQuery());
+    assertEquals(1, projectScan.getColumnList().size());
+    ResolvedConstant resolvedConstant =
+        assertInstanceOf(ResolvedConstant.class, projectScan.getExprList().get(0).getExpr());
+    assertEquals("x", resolvedConstant.getConstant().getFullName());
+    assertTrue(resolvedConstant.getConstant().getType().isInt64());
+  }
+
+  @Test
+  void testTypeCoercion() {
+    // Invalid type for the default value
+    String query = "DECLARE x INT64 DEFAULT 'ASD';";
+    Iterator<AnalyzedStatement> statementIterator = this.analyzer.analyzeStatements(query);
+    assertThrows(AnalysisException.class, statementIterator::next);
+
+    // Invalid type for SET statement
+    query = "DECLARE x INT64;\n"
+      + "SET x = 'ASD';";
+    statementIterator = this.analyzer.analyzeStatements(query);
+    statementIterator.next();
+    assertThrows(AnalysisException.class, statementIterator::next);
+  }
+
 }

--- a/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/ZetaSQLToolkitTest.java
+++ b/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/ZetaSQLToolkitTest.java
@@ -40,9 +40,11 @@ public class ZetaSQLToolkitTest {
   void testSimpleSelectStmt() {
     String stmt = "SELECT 1 AS col";
 
-    ResolvedStatement analyzedStmt = this.analyzer.analyzeStatements(stmt).next();
+    AnalyzedStatement analyzedStmt = this.analyzer.analyzeStatements(stmt).next();
 
-    ResolvedQueryStmt queryStmt = assertInstanceOf(ResolvedQueryStmt.class, analyzedStmt);
+    assertTrue(analyzedStmt.getResolvedStatement().isPresent());
+    ResolvedQueryStmt queryStmt =
+        assertInstanceOf(ResolvedQueryStmt.class, analyzedStmt.getResolvedStatement().get());
 
     ResolvedProjectScan projectScan =
         assertInstanceOf(ResolvedProjectScan.class, queryStmt.getQuery());

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeBigQuery.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeBigQuery.java
@@ -16,8 +16,17 @@
 
 package com.google.zetasql.toolkit.examples;
 
+import com.google.common.collect.ImmutableList;
 import com.google.zetasql.AnalyzerOptions;
+import com.google.zetasql.Constant;
+import com.google.zetasql.SimpleConstantProtos.SimpleConstantProto;
+import com.google.zetasql.TypeFactory;
+import com.google.zetasql.ZetaSQLType.TypeKind;
+import com.google.zetasql.ZetaSQLType.TypeProto;
+import com.google.zetasql.parser.ASTNodes.ASTStatement;
+import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedLiteral;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
+import com.google.zetasql.toolkit.AnalyzedStatement;
 import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
 import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
@@ -32,6 +41,8 @@ public class AnalyzeBigQuery {
   public static void main(String[] args) {
     // Analyzing a query that uses bigquery-public-data tables
     String query =
+        "DECLARE x STRING DEFAULT 'ASD';" +
+        "SET x = 'ASD2';" +
         "INSERT INTO `bigquery-public-data.samples.wikipedia` (title) VALUES ('random title');\n"
             + "SELECT title, language FROM `bigquery-public-data.samples.wikipedia` WHERE title = 'random title';";
 
@@ -66,9 +77,10 @@ public class AnalyzeBigQuery {
     // Step 4: Use the ZetaSQLToolkitAnalyzer to get an iterator of the ResolvedStatements
     // that result from running the analysis
     ZetaSQLToolkitAnalyzer analyzer = new ZetaSQLToolkitAnalyzer(options);
-    Iterator<ResolvedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
+    Iterator<AnalyzedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
 
     // Step 5: Consume the previous iterator and use the ResolvedStatements however you need
-    statementIterator.forEachRemaining(statement -> System.out.println(statement.debugString()));
+    statementIterator.forEachRemaining(statement ->
+        statement.getResolvedStatement().ifPresent(System.out::println));
   }
 }

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeCloudSpanner.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeCloudSpanner.java
@@ -61,6 +61,7 @@ public class AnalyzeCloudSpanner {
     ZetaSQLToolkitAnalyzer analyzer = new ZetaSQLToolkitAnalyzer(options);
     analyzer
         .analyzeStatements(query, catalog)
-        .forEachRemaining(statement -> System.out.println(statement.debugString()));
+        .forEachRemaining(statement ->
+            statement.getResolvedStatement().ifPresent(System.out::println));
   }
 }

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeWithoutCatalog.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeWithoutCatalog.java
@@ -19,6 +19,7 @@ package com.google.zetasql.toolkit.examples;
 import com.google.zetasql.AnalyzerOptions;
 import com.google.zetasql.LanguageOptions;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
+import com.google.zetasql.toolkit.AnalyzedStatement;
 import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
 import java.util.Iterator;
 
@@ -50,9 +51,10 @@ public class AnalyzeWithoutCatalog {
     // Step 2: Use the ZetaSQLToolkitAnalyzer to get an iterator of the ResolvedStatements
     // that result from running the analysis
     ZetaSQLToolkitAnalyzer analyzer = new ZetaSQLToolkitAnalyzer(analyzerOptions);
-    Iterator<ResolvedStatement> statementIterator = analyzer.analyzeStatements(query);
+    Iterator<AnalyzedStatement> statementIterator = analyzer.analyzeStatements(query);
 
     // Step 3: Consume the previous iterator and use the ResolvedStatements however you need
-    statementIterator.forEachRemaining(statement -> System.out.println(statement.debugString()));
+    statementIterator.forEachRemaining(statement ->
+        statement.getResolvedStatement().ifPresent(System.out::println));
   }
 }

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzingCreateStatements.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzingCreateStatements.java
@@ -18,6 +18,7 @@ package com.google.zetasql.toolkit.examples;
 
 import com.google.zetasql.AnalyzerOptions;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
+import com.google.zetasql.toolkit.AnalyzedStatement;
 import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
 import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
@@ -45,8 +46,9 @@ public class AnalyzingCreateStatements {
     options.setLanguageOptions(BigQueryLanguageOptions.get());
 
     ZetaSQLToolkitAnalyzer analyzer = new ZetaSQLToolkitAnalyzer(options);
-    Iterator<ResolvedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
+    Iterator<AnalyzedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
 
-    statementIterator.forEachRemaining(statement -> System.out.println(statement.debugString()));
+    statementIterator.forEachRemaining(statement ->
+        statement.getResolvedStatement().ifPresent(System.out::println));
   }
 }

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/LoadTablesUsedInQuery.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/LoadTablesUsedInQuery.java
@@ -18,6 +18,7 @@ package com.google.zetasql.toolkit.examples;
 
 import com.google.zetasql.AnalyzerOptions;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
+import com.google.zetasql.toolkit.AnalyzedStatement;
 import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
 import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
@@ -43,8 +44,9 @@ public class LoadTablesUsedInQuery {
     catalog.addAllTablesUsedInQuery(query, options);
 
     ZetaSQLToolkitAnalyzer analyzer = new ZetaSQLToolkitAnalyzer(options);
-    Iterator<ResolvedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
+    Iterator<AnalyzedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
 
-    statementIterator.forEachRemaining(statement -> System.out.println(statement.debugString()));
+    statementIterator.forEachRemaining(statement ->
+        statement.getResolvedStatement().ifPresent(System.out::println));
   }
 }

--- a/zetasql-toolkit-spanner/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
+++ b/zetasql-toolkit-spanner/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
@@ -20,6 +20,7 @@ import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Spanner;
 import com.google.zetasql.Analyzer;
 import com.google.zetasql.AnalyzerOptions;
+import com.google.zetasql.Constant;
 import com.google.zetasql.SimpleCatalog;
 import com.google.zetasql.SimpleTable;
 import com.google.zetasql.ZetaSQLBuiltinFunctionOptions;
@@ -169,6 +170,11 @@ public class SpannerCatalog implements CatalogWrapper {
   public void register(
       ProcedureInfo procedureInfo, CreateMode createMode, CreateScope createScope) {
     throw new UnsupportedOperationException("Cloud Spanner does not support procedures");
+  }
+
+  @Override
+  public void register(Constant constant) {
+    throw new UnsupportedOperationException("Cloud Spanner does not support constants");
   }
 
   @Override


### PR DESCRIPTION
Adds support for analyzing variable declarations and assignments. While the ZetaSQL Analyzer does not support any kind of script statement, we now can handle jobs that include variable declarations and assignments. 

`ZetaSQLToolkitAnalyzer.analyzeStatements()` now returns an `Iterator<AnalyzedStatement>`; where each `AnalyzedStatement` has the parsed statement and, optionally, the resolved statement. The resolved statement is only available for statement that can be analyzed.

When encountering a variable declaration, we create a `Constant` in the Catalog. We also validate the default value expression, if provided.

When encountering an assignment; we validate it and check if the expression is valid, if the variable being assigned to exists and if the expression coerces to the variable type.