### PR TITLE
Support creating catalogs from JSON objects

### DIFF
--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProvider.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProvider.java
@@ -432,7 +432,7 @@ public class BigQueryAPIResourceProvider implements BigQueryResourceProvider {
         .setMode(Mode.SCALAR)
         .setSignatures(List.of(signature))
         .setLanguage(FunctionInfo.Language.valueOfOrUnspecified(routine.getLanguage()))
-        .setBody(routine.getBody())
+        .setBody(Optional.ofNullable(routine.getBody()))
         .build();
   }
 
@@ -468,7 +468,7 @@ public class BigQueryAPIResourceProvider implements BigQueryResourceProvider {
         .setNamePath(bigQueryReference.getNamePath())
         .setSignature(signature)
         .setOutputSchema(maybeOutputSchema)
-        .setBody(routine.getBody())
+        .setBody(Optional.ofNullable(routine.getBody()))
         .build();
   }
 

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
@@ -17,6 +17,7 @@
 package com.google.zetasql.toolkit.catalog.bigquery;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.gson.JsonParseException;
 import com.google.zetasql.*;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateMode;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateScope;
@@ -29,6 +30,7 @@ import com.google.zetasql.toolkit.catalog.TVFInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.exceptions.BigQueryCreateError;
 import com.google.zetasql.toolkit.catalog.bigquery.exceptions.MissingFunctionResultType;
 import com.google.zetasql.toolkit.catalog.exceptions.CatalogResourceAlreadyExists;
+import com.google.zetasql.toolkit.catalog.io.CatalogResources;
 import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
 import java.util.Arrays;
 import java.util.List;
@@ -54,12 +56,12 @@ public class BigQueryCatalog implements CatalogWrapper {
    * Constructs a BigQueryCatalog that fetches resources from the BigQuery API using application
    * default credentials.
    *
-   * <p>A BigQueryCatalog constructed this way will use the default {@link
-   * BigQueryAPIResourceProvider} for accessing the API.
+   * @deprecated Use {@link BigQueryCatalog#usingBigQueryAPI(String)}
    *
    * @param defaultProjectId The BigQuery default project id, queries are assumed to be running on
    *     this project
    */
+  @Deprecated(since = "0.4.0", forRemoval = true)
   public BigQueryCatalog(String defaultProjectId) {
     this(defaultProjectId, BigQueryAPIResourceProvider.buildDefault());
   }
@@ -68,13 +70,13 @@ public class BigQueryCatalog implements CatalogWrapper {
    * Constructs a BigQueryCatalog that fetches resources from the BigQuery API using the provided
    * BigQuery Client.
    *
-   * <p>A BigQueryCatalog constructed this way will use the {@link BigQueryAPIResourceProvider} for
-   * accessing the API using the provided BigQuery client.
+   * @deprecated Use {@link BigQueryCatalog#usingBigQueryAPI(String, BigQuery)}
    *
    * @param defaultProjectId The BigQuery default project id, queries are assumed to be running on
    *     this project
    * @param bigQueryClient The BigQuery client to use for accessing the API
    */
+  @Deprecated(since = "0.4.0", forRemoval = true)
   public BigQueryCatalog(String defaultProjectId, BigQuery bigQueryClient) {
     this(defaultProjectId, BigQueryAPIResourceProvider.build(bigQueryClient));
   }
@@ -106,6 +108,51 @@ public class BigQueryCatalog implements CatalogWrapper {
     this.defaultProjectId = defaultProjectId;
     this.bigQueryResourceProvider = bigQueryResourceProvider;
     this.catalog = internalCatalog;
+  }
+
+  /**
+   * Constructs a BigQueryCatalog that fetches resources from the BigQuery API using application
+   * default credentials.
+   *
+   * <p>A BigQueryCatalog constructed this way will use the default {@link
+   * BigQueryAPIResourceProvider} for accessing the API.
+   *
+   * @param defaultProjectId The BigQuery default project id, queries are assumed to be running on
+   *     this project
+   */
+  public static BigQueryCatalog usingBigQueryAPI(String defaultProjectId) {
+    BigQueryResourceProvider resourceProvider = BigQueryAPIResourceProvider.buildDefault();
+    return new BigQueryCatalog(defaultProjectId, resourceProvider);
+  }
+
+  /**
+   * Constructs a BigQueryCatalog that fetches resources from the BigQuery API using the provided
+   * BigQuery Client.
+   *
+   * <p>A BigQueryCatalog constructed this way will use the {@link BigQueryAPIResourceProvider} for
+   * accessing the API using the provided BigQuery client.
+   *
+   * @param defaultProjectId The BigQuery default project id, queries are assumed to be running on
+   *     this project
+   * @param bigQueryClient The BigQuery client to use for accessing the API
+   */
+  public static BigQueryCatalog usingBigQueryAPI(String defaultProjectId, BigQuery bigQueryClient) {
+    BigQueryResourceProvider resourceProvider = BigQueryAPIResourceProvider.build(bigQueryClient);
+    return new BigQueryCatalog(defaultProjectId, resourceProvider);
+  }
+
+  /**
+   * Constructs a BigQueryCatalog that can use the resources in the provided
+   * {@link CatalogResources} object.
+   *
+   * @param defaultProjectId The BigQuery default project id, queries are assumed to be running on
+   *     this project
+   * @param resources The {@link CatalogResources} object from which this catalog will get resources
+   */
+  public static BigQueryCatalog usingResources(String defaultProjectId, CatalogResources resources)
+      throws JsonParseException {
+    LocalBigQueryResourceProvider resourceProvider = new LocalBigQueryResourceProvider(resources);
+    return new BigQueryCatalog(defaultProjectId, resourceProvider);
   }
 
   /**

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryReference.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryReference.java
@@ -24,6 +24,7 @@ import com.google.zetasql.toolkit.catalog.bigquery.exceptions.InvalidBigQueryRef
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /** Dataclass representing a reference to a BigQuery resource. */
@@ -118,4 +119,26 @@ class BigQueryReference {
   public RoutineId toRoutineId() {
     return RoutineId.of(this.getProjectId(), this.getDatasetId(), this.getResourceName());
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof BigQueryReference)) {
+      return false;
+    }
+
+    BigQueryReference other = (BigQueryReference) o;
+    return projectId.equalsIgnoreCase(other.getProjectId())
+        && datasetId.equals(other.getDatasetId())
+        && resourceName.equals(other.getResourceName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(projectId.toLowerCase(), datasetId, resourceName);
+  }
+
 }

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/LocalBigQueryResourceProvider.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/LocalBigQueryResourceProvider.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.catalog.bigquery;
+
+import com.google.zetasql.SimpleTable;
+import com.google.zetasql.toolkit.catalog.FunctionInfo;
+import com.google.zetasql.toolkit.catalog.ProcedureInfo;
+import com.google.zetasql.toolkit.catalog.TVFInfo;
+import com.google.zetasql.toolkit.catalog.io.CatalogResources;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * {@link BigQueryResourceProvider} implementation that fetches catalog resources from a local
+ * {@link CatalogResources} object.
+ */
+public class LocalBigQueryResourceProvider implements BigQueryResourceProvider {
+
+  private final CatalogResources catalogResources;
+
+  public LocalBigQueryResourceProvider(CatalogResources catalogResources) {
+    this.catalogResources = catalogResources;
+  }
+
+  private Set<BigQueryReference> parseBigQueryReferences(
+      String projectId, List<String> references) {
+    return references.stream()
+        .map(reference -> BigQueryReference.from(projectId, reference))
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public List<SimpleTable> getTables(String projectId, List<String> tableReferences) {
+    Set<BigQueryReference> references = parseBigQueryReferences(projectId, tableReferences);
+
+    return catalogResources.getTables()
+        .stream()
+        .filter(table -> {
+          BigQueryReference tableReference = BigQueryReference.from(projectId, table.getName());
+          return references.contains(tableReference);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<SimpleTable> getAllTablesInDataset(String projectId, String datasetName) {
+    return catalogResources.getTables()
+        .stream()
+        .filter(table -> {
+          BigQueryReference tableReference = BigQueryReference.from(projectId, table.getName());
+          return tableReference.getProjectId().equalsIgnoreCase(projectId)
+              && tableReference.getDatasetId().equals(datasetName);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<SimpleTable> getAllTablesInProject(String projectId) {
+    return catalogResources.getTables()
+        .stream()
+        .filter(table -> {
+          BigQueryReference tableReference = BigQueryReference.from(projectId, table.getName());
+          return tableReference.getProjectId().equalsIgnoreCase(projectId);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<FunctionInfo> getFunctions(String projectId, List<String> functionReferences) {
+    Set<BigQueryReference> references = parseBigQueryReferences(projectId, functionReferences);
+
+    return catalogResources.getFunctions()
+        .stream()
+        .filter(function -> {
+          BigQueryReference functionReference =
+              BigQueryReference.from(projectId, function.getFullName());
+          return references.contains(functionReference);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<FunctionInfo> getAllFunctionsInDataset(String projectId, String datasetName) {
+    return catalogResources.getFunctions()
+        .stream()
+        .filter(function -> {
+          BigQueryReference functionReference =
+              BigQueryReference.from(projectId, function.getFullName());
+          return functionReference.getProjectId().equalsIgnoreCase(projectId)
+              && functionReference.getDatasetId().equals(datasetName);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<FunctionInfo> getAllFunctionsInProject(String projectId) {
+    return catalogResources.getFunctions()
+        .stream()
+        .filter(function -> {
+          BigQueryReference functionReference =
+              BigQueryReference.from(projectId, function.getFullName());
+          return functionReference.getProjectId().equalsIgnoreCase(projectId);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<TVFInfo> getTVFs(String projectId, List<String> functionReferences) {
+    Set<BigQueryReference> references = parseBigQueryReferences(projectId, functionReferences);
+
+    return catalogResources.getTVFs()
+        .stream()
+        .filter(tvf -> {
+          BigQueryReference functionReference =
+              BigQueryReference.from(projectId, tvf.getFullName());
+          return references.contains(functionReference);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<TVFInfo> getAllTVFsInDataset(String projectId, String datasetName) {
+    return catalogResources.getTVFs()
+        .stream()
+        .filter(tvf -> {
+          BigQueryReference functionReference =
+              BigQueryReference.from(projectId, tvf.getFullName());
+          return functionReference.getProjectId().equalsIgnoreCase(projectId)
+              && functionReference.getDatasetId().equals(datasetName);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<TVFInfo> getAllTVFsInProject(String projectId) {
+    return catalogResources.getTVFs()
+        .stream()
+        .filter(tvf -> {
+          BigQueryReference functionReference =
+              BigQueryReference.from(projectId, tvf.getFullName());
+          return functionReference.getProjectId().equalsIgnoreCase(projectId);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<ProcedureInfo> getProcedures(String projectId, List<String> procedureReferences) {
+    Set<BigQueryReference> references = parseBigQueryReferences(projectId, procedureReferences);
+
+    return catalogResources.getProcedures()
+        .stream()
+        .filter(procedure -> {
+          BigQueryReference procedureReference =
+              BigQueryReference.from(projectId, procedure.getFullName());
+          return references.contains(procedureReference);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<ProcedureInfo> getAllProceduresInDataset(String projectId, String datasetName) {
+    return catalogResources.getProcedures()
+        .stream()
+        .filter(procedure -> {
+          BigQueryReference procedureReference =
+              BigQueryReference.from(projectId, procedure.getFullName());
+          return procedureReference.getProjectId().equalsIgnoreCase(projectId)
+              && procedureReference.getDatasetId().equals(datasetName);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<ProcedureInfo> getAllProceduresInProject(String projectId) {
+    return catalogResources.getProcedures()
+        .stream()
+        .filter(procedure -> {
+          BigQueryReference procedureReference =
+              BigQueryReference.from(projectId, procedure.getFullName());
+          return procedureReference.getProjectId().equalsIgnoreCase(projectId);
+        })
+        .collect(Collectors.toList());
+  }
+
+}

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/FunctionInfo.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/FunctionInfo.java
@@ -16,6 +16,7 @@
 
 package com.google.zetasql.toolkit.catalog;
 
+import com.google.common.base.Preconditions;
 import com.google.zetasql.FunctionSignature;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
 import java.util.List;
@@ -43,17 +44,17 @@ public class FunctionInfo {
 
   private final List<FunctionSignature> signatures;
 
-  private final Optional<Language> language;
+  private final Language language;
 
-  private final Optional<String> body;
+  private final String body;
 
   private FunctionInfo(Builder builder) {
     this.namePath = builder.getNamePath();
     this.group = builder.getGroup();
     this.mode = builder.getMode();
     this.signatures = builder.getSignatures();
-    this.language = builder.getLanguage();
-    this.body = builder.getBody();
+    this.language = builder.getLanguage().orElse(null);
+    this.body = builder.getBody().orElse(null);
   }
 
   public List<String> getNamePath() {
@@ -73,11 +74,11 @@ public class FunctionInfo {
   }
 
   public Optional<Language> getLanguage() {
-    return language;
+    return Optional.ofNullable(this.language);
   }
 
   public Optional<String> getBody() {
-    return this.body;
+    return Optional.ofNullable(this.body);
   }
 
   public Builder toBuilder() {
@@ -86,8 +87,8 @@ public class FunctionInfo {
         .setGroup(this.group)
         .setMode(this.mode)
         .setSignatures(this.signatures)
-        .setLanguage(this.language)
-        .setBody(this.body);
+        .setLanguage(this.getLanguage())
+        .setBody(this.getBody());
   }
 
   public static Builder newBuilder() {
@@ -99,8 +100,8 @@ public class FunctionInfo {
     private String group;
     private Mode mode;
     private List<FunctionSignature> signatures;
-    private Optional<Language> language;
-    private Optional<String> body;
+    private Optional<Language> language = Optional.empty();
+    private Optional<String> body = Optional.empty();
 
     public Builder setNamePath(List<String> namePath) {
       this.namePath = namePath;
@@ -123,7 +124,8 @@ public class FunctionInfo {
     }
 
     public Builder setLanguage(Language language) {
-      this.language = Optional.ofNullable(language);
+      Preconditions.checkNotNull(language);
+      this.language = Optional.of(language);
       return this;
     }
 
@@ -133,7 +135,8 @@ public class FunctionInfo {
     }
 
     public Builder setBody(String body) {
-      this.body = Optional.ofNullable(body);
+      Preconditions.checkNotNull(body);
+      this.body = Optional.of(body);
       return this;
     }
 

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/FunctionInfo.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/FunctionInfo.java
@@ -81,6 +81,10 @@ public class FunctionInfo {
     return Optional.ofNullable(this.body);
   }
 
+  public String getFullName() {
+    return String.join(".", namePath);
+  }
+
   public Builder toBuilder() {
     return newBuilder()
         .setNamePath(this.namePath)

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/ProcedureInfo.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/ProcedureInfo.java
@@ -46,4 +46,9 @@ public class ProcedureInfo {
   public FunctionSignature getSignature() {
     return signature;
   }
+
+  public String getFullName() {
+    return String.join(".", namePath);
+  }
+
 }

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/TVFInfo.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/TVFInfo.java
@@ -31,15 +31,15 @@ public class TVFInfo {
 
   private final FunctionSignature signature;
 
-  private final Optional<TVFRelation> outputSchema;
+  private final TVFRelation outputSchema;
 
-  private final Optional<String> body;
+  private final String body;
 
   private TVFInfo(Builder builder) {
     this.namePath = builder.getNamePath();
     this.signature = builder.getSignature();
-    this.outputSchema = builder.getOutputSchema();
-    this.body = builder.getBody();
+    this.outputSchema = builder.getOutputSchema().orElse(null);
+    this.body = builder.getBody().orElse(null);
   }
 
   public ImmutableList<String> getNamePath() {
@@ -51,19 +51,19 @@ public class TVFInfo {
   }
 
   public Optional<TVFRelation> getOutputSchema() {
-    return outputSchema;
+    return Optional.ofNullable(this.outputSchema);
   }
 
   public Optional<String> getBody() {
-    return body;
+    return Optional.ofNullable(this.body);
   }
 
   public Builder toBuilder() {
     return newBuilder()
         .setNamePath(this.namePath)
         .setSignature(this.signature)
-        .setOutputSchema(this.outputSchema)
-        .setBody(this.body);
+        .setOutputSchema(this.getOutputSchema())
+        .setBody(this.getBody());
   }
 
   public static Builder newBuilder() {
@@ -76,9 +76,9 @@ public class TVFInfo {
 
     private FunctionSignature signature;
 
-    private Optional<TVFRelation> outputSchema;
+    private Optional<TVFRelation> outputSchema = Optional.empty();
 
-    private Optional<String> body;
+    private Optional<String> body = Optional.empty();
 
     public Builder setNamePath(ImmutableList<String> namePath) {
       this.namePath = namePath;
@@ -91,7 +91,8 @@ public class TVFInfo {
     }
 
     public Builder setOutputSchema(TVFRelation outputSchema) {
-      this.outputSchema = Optional.ofNullable(outputSchema);
+      Preconditions.checkNotNull(outputSchema);
+      this.outputSchema = Optional.of(outputSchema);
       return this;
     }
 
@@ -101,7 +102,8 @@ public class TVFInfo {
     }
 
     public Builder setBody(String body) {
-      this.body = Optional.ofNullable(body);
+      Preconditions.checkNotNull(body);
+      this.body = Optional.of(body);
       return this;
     }
 

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/TVFInfo.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/TVFInfo.java
@@ -58,6 +58,10 @@ public class TVFInfo {
     return Optional.ofNullable(this.body);
   }
 
+  public String getFullName() {
+    return String.join(".", namePath);
+  }
+
   public Builder toBuilder() {
     return newBuilder()
         .setNamePath(this.namePath)

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/io/CatalogResources.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/io/CatalogResources.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.catalog.io;
+
+import com.google.gson.JsonParseException;
+import com.google.zetasql.SimpleTable;
+import com.google.zetasql.toolkit.catalog.FunctionInfo;
+import com.google.zetasql.toolkit.catalog.ProcedureInfo;
+import com.google.zetasql.toolkit.catalog.TVFInfo;
+import java.util.List;
+
+/**
+ * Dataclass containing the resources of a Catalog
+ */
+public class CatalogResources {
+
+  private final List<SimpleTable> tables;
+  private final List<FunctionInfo> functions;
+  private final List<TVFInfo> tvfs;
+  private final List<ProcedureInfo> procedures;
+
+  public CatalogResources(
+      List<SimpleTable> tables,
+      List<FunctionInfo> functions,
+      List<TVFInfo> tvfs,
+      List<ProcedureInfo> procedures) {
+    this.tables = tables;
+    this.functions = functions;
+    this.tvfs = tvfs;
+    this.procedures = procedures;
+  }
+
+  public List<SimpleTable> getTables() {
+    return tables != null ? tables : List.of();
+  }
+
+  public List<FunctionInfo> getFunctions() {
+    return functions != null ? functions : List.of();
+  }
+
+  public List<TVFInfo> getTVFs() {
+    return tvfs != null ? tvfs : List.of();
+  }
+
+  public List<ProcedureInfo> getProcedures() {
+    return procedures != null ? procedures : List.of();
+  }
+
+  /**
+   * Deserializes a JSON object representing a Catalog into a {@link CatalogResources} instance. 
+   * JSON objects representing catalogs support tables, scalar functions, TVFs and procedures.
+   *
+   * <pre>
+   * JSON objects should follow the following format:
+   *
+   * {
+   *   "tables": [
+   *     {
+   *       "name": "project.dataset.table",
+   *       "columns": [
+   *         { "name": "column", "type": "INT64" },
+   *         { "name": "column2", "type": "TIMESTAMP", "isPseudoColumn": true }
+   *       ]
+   *     }
+   *   ],
+   *   "functions": [
+   *     {
+   *       "name": "project.dataset.function",
+   *       "signatures": [
+   *         {
+   *           "arguments": [
+   *             {  "name": "arg1", "type": "ARRAY&lt;STRING&gt;" }
+   *           ],
+   *           "returnType": "STRING"
+   *         }
+   *       ]
+   *     }
+   *   ],
+   *   "tvfs": [
+   *     {
+   *       "name": "project.dataset.tvf",
+   *       "arguments": [
+   *         { "name": "arg1", "type": "ARRAY&lt;STRUCT&lt;x INT64&gt;&gt;" }
+   *       ],
+   *       "outputColumns": [
+   *         { "name": "out1", "type": "INT64" }
+   *       ]
+   *     }
+   *   ],
+   *   "procedures": [
+   *     {
+   *       "name": "project.dataset.proc",
+   *       "arguments": [
+   *         { "name": "arg1", "type": "ARRAY&lt;STRUCT&lt;x INT64&gt;&gt;" }
+   *       ]
+   *     }
+   *   ]
+   * }
+   * </pre>
+   * 
+   * @param json The JSON string for the object to deserialize into {@link CatalogResources}
+   * @return The resulting {@link CatalogResources} instance
+   * @throws JsonParseException when parsing the JSON catalog fails
+   */
+  public static CatalogResources fromJson(String json) {
+    return JsonCatalogDeserializer.readJsonCatalog(json);
+  }
+
+}

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/io/JsonCatalogDeserializer.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/io/JsonCatalogDeserializer.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.catalog.io;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.zetasql.FunctionArgumentType;
+import com.google.zetasql.FunctionArgumentType.FunctionArgumentTypeOptions;
+import com.google.zetasql.FunctionSignature;
+import com.google.zetasql.SimpleColumn;
+import com.google.zetasql.SimpleTable;
+import com.google.zetasql.TVFRelation;
+import com.google.zetasql.Type;
+import com.google.zetasql.TypeFactory;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.NamedArgumentKind;
+import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
+import com.google.zetasql.ZetaSQLType.TypeKind;
+import com.google.zetasql.toolkit.catalog.FunctionInfo;
+import com.google.zetasql.toolkit.catalog.ProcedureInfo;
+import com.google.zetasql.toolkit.catalog.TVFInfo;
+import com.google.zetasql.toolkit.catalog.typeparser.ZetaSQLTypeParseError;
+import com.google.zetasql.toolkit.catalog.typeparser.ZetaSQLTypeParser;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Implements deserialization of {@link CatalogResources} from JSON objects. JSON objects
+ * representing catalogs support tables, scalar functions, TVFs and procedures.
+ *
+ * <pre>
+ * JSON objects should follow the following format:
+ *
+ * {
+ *   "tables": [
+ *     {
+ *       "name": "project.dataset.table",
+ *       "columns": [
+ *         { "name": "column", "type": "INT64" },
+ *         { "name": "column2", "type": "TIMESTAMP", "isPseudoColumn": true }
+ *       ]
+ *     }
+ *   ],
+ *   "functions": [
+ *     {
+ *       "name": "project.dataset.function",
+ *       "signatures": [
+ *         {
+ *           "arguments": [
+ *             {  "name": "arg1", "type": "ARRAY&lt;STRING&gt;" }
+ *           ],
+ *           "returnType": "STRING"
+ *         }
+ *       ]
+ *     }
+ *   ],
+ *   "tvfs": [
+ *     {
+ *       "name": "project.dataset.tvf",
+ *       "arguments": [
+ *         { "name": "arg1", "type": "ARRAY&lt;STRUCT&lt;x INT64&gt;&gt;" }
+ *       ],
+ *       "outputColumns": [
+ *         { "name": "out1", "type": "INT64" }
+ *       ]
+ *     }
+ *   ],
+ *   "procedures": [
+ *     {
+ *       "name": "project.dataset.proc",
+ *       "arguments": [
+ *         { "name": "arg1", "type": "ARRAY&lt;STRUCT&lt;x INT64&gt;&gt;" }
+ *       ]
+ *     }
+ *   ]
+ * }
+ * </pre>
+ *
+ */
+class JsonCatalogDeserializer {
+
+  /**
+   * {@link Gson} instance used when deserializing. Registers all custom deserializers defined in
+   * this class.
+   */
+  private static final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(SimpleTable.class, new TableDeserializer())
+      .registerTypeAdapter(FunctionInfo.class, new FunctionDeserializer())
+      .registerTypeAdapter(FunctionSignature.class, new FunctionSignatureDeserializer())
+      .registerTypeAdapter(FunctionArgumentType.class, new FunctionArgumentTypeDeserializer())
+      .registerTypeAdapter(TVFInfo.class, new TVFDeserializer())
+      .registerTypeAdapter(ProcedureInfo.class, new ProcedureDeserializer())
+      .create();
+
+  /**
+   * Deserializes the {@link CatalogResources} represented by the provided JSON object
+   *
+   * @param json The JSON string for the object to deserialize into {@link CatalogResources}
+   * @return The resulting {@link CatalogResources} instance
+   * @throws JsonParseException when parsing the JSON catalog fails
+   */
+  public static CatalogResources readJsonCatalog(String json) throws JsonParseException {
+    return gson.fromJson(json, CatalogResources.class);
+  }
+
+  private static JsonObject getAsJsonObject(JsonElement jsonElement, String errorMessage) {
+    if (!jsonElement.isJsonObject()) {
+      throw new JsonParseException(errorMessage);
+    }
+
+    return jsonElement.getAsJsonObject();
+  }
+
+  private static JsonArray getFieldAsJsonArray(
+      JsonObject jsonObject, String fieldName, String errorMessage) {
+    return Optional.ofNullable(jsonObject.get(fieldName))
+        .filter(JsonElement::isJsonArray)
+        .map(JsonElement::getAsJsonArray)
+        .orElseThrow(() -> new JsonParseException(errorMessage));
+  }
+
+  private static String getFieldAsString(
+      JsonObject jsonObject, String fieldName, String errorMessage) {
+    JsonElement field = jsonObject.get(fieldName);
+
+    if (Objects.isNull(field)
+        || !field.isJsonPrimitive()
+        || !field.getAsJsonPrimitive().isString()) {
+      throw new JsonParseException(errorMessage);
+    }
+
+    return field.getAsString();
+  }
+
+  private static boolean getFieldAsBoolean(
+      JsonObject jsonObject, String fieldName, String errorMessage) {
+    JsonElement field = jsonObject.get(fieldName);
+
+    if (Objects.isNull(field) || !field.isJsonPrimitive()) {
+      throw new JsonParseException(errorMessage);
+    }
+
+    JsonPrimitive primitive = field.getAsJsonPrimitive();
+    boolean isTrueOrFalseString = primitive.isString()
+        && List.of("true", "false").contains(primitive.getAsString().toLowerCase());
+
+    if (!primitive.isBoolean() && !isTrueOrFalseString) {
+      throw new JsonParseException(errorMessage);
+    }
+
+    return primitive.getAsBoolean();
+  }
+
+  private static Type parseType(String type) {
+    try {
+      return ZetaSQLTypeParser.parse(type);
+    } catch (ZetaSQLTypeParseError err) {
+      throw new JsonParseException("Invalid SQL type: " + type, err);
+    }
+  }
+
+  private static SimpleColumn deserializeSimpleColumn(String tableName, JsonObject jsonColumn) {
+    String columnName = getFieldAsString(
+        jsonColumn, "name",
+        "Invalid JSON column " + jsonColumn + ". Field name should be string");
+    String columnType = getFieldAsString(
+        jsonColumn, "type",
+        "Invalid JSON column " + jsonColumn + ". Field type should be string");
+
+    Type parsedType = parseType(columnType);
+
+    boolean isPseudoColumn = jsonColumn.has("isPseudoColumn")
+        && getFieldAsBoolean(jsonColumn, "isPseudoColumn",
+          "Invalid JSON column " + jsonColumn + ". Field isPseudoColumn should be bool");
+
+    boolean isWriteableColumn = !isPseudoColumn;
+
+    return new SimpleColumn(tableName, columnName, parsedType, isPseudoColumn, isWriteableColumn);
+  }
+
+  private static TVFRelation.Column deserializeTVFOutputColumn(JsonObject jsonColumn) {
+    SimpleColumn deserializedSimpleColumn = deserializeSimpleColumn("", jsonColumn);
+    return TVFRelation.Column.create(
+        deserializedSimpleColumn.getName(),
+        deserializedSimpleColumn.getType());
+  }
+
+  /**
+   * Gson deserializer for {@link SimpleTable}
+   */
+  private static class TableDeserializer implements JsonDeserializer<SimpleTable> {
+
+    @Override
+    public SimpleTable deserialize(
+        JsonElement jsonElement,
+        java.lang.reflect.Type type,
+        JsonDeserializationContext context
+    ) throws JsonParseException {
+      JsonObject jsonObject = getAsJsonObject(
+          jsonElement,
+          "Invalid JSON table: " + jsonElement + ". Tables should be objects.");
+
+      String tableName = getFieldAsString(
+          jsonObject, "name",
+          "Invalid JSON table: " + jsonElement + ". Field name should be string.");
+
+      JsonArray columns = getFieldAsJsonArray(
+          jsonObject, "columns",
+          "Invalid JSON table: " + jsonElement + ". Field columns should be array of columns.");
+
+      List<SimpleColumn> parsedColumns = columns
+          .asList()
+          .stream()
+          .map(jsonColumn ->
+              getAsJsonObject(jsonColumn,
+                  "Invalid JSON column " + jsonColumn + ". Should be JSON object."))
+          .map(jsonColumn -> deserializeSimpleColumn(tableName, jsonColumn))
+          .collect(Collectors.toList());
+
+      return new SimpleTable(tableName, parsedColumns);
+    }
+  }
+
+  /**
+   * Gson deserializer for {@link FunctionInfo}
+   */
+  private static class FunctionDeserializer implements JsonDeserializer<FunctionInfo> {
+
+    @Override
+    public FunctionInfo deserialize(
+        JsonElement jsonElement,
+        java.lang.reflect.Type type,
+        JsonDeserializationContext context
+    ) throws JsonParseException {
+      JsonObject jsonObject = getAsJsonObject(
+          jsonElement,
+          "Invalid JSON function: " + jsonElement + ". Functions should be objects.");
+
+      String functionName = getFieldAsString(
+          jsonObject, "name",
+          "Invalid JSON function: " + jsonElement + ". Field name should be string.");
+
+      FunctionSignature[] signatures = Optional.ofNullable(jsonObject.get("signatures"))
+          .map(jsonSignatures -> context.deserialize(jsonSignatures, FunctionSignature[].class))
+          .map(FunctionSignature[].class::cast)
+          .orElseThrow(() -> new JsonParseException(
+              "Invalid JSON function: " + jsonElement + ". Signatures missing."));
+
+      return FunctionInfo.newBuilder()
+          .setNamePath(List.of(functionName))
+          .setGroup("UDF")
+          .setMode(Mode.SCALAR)
+          .setSignatures(Arrays.asList(signatures))
+          .build();
+    }
+  }
+
+  /**
+   * Gson deserializer for {@link FunctionSignature}
+   */
+  private static class FunctionSignatureDeserializer implements JsonDeserializer<FunctionSignature> {
+
+    @Override
+    public FunctionSignature deserialize(
+        JsonElement jsonElement,
+        java.lang.reflect.Type type,
+        JsonDeserializationContext context
+    ) throws JsonParseException {
+      JsonObject jsonObject = getAsJsonObject(
+          jsonElement,
+          "Invalid JSON function signature: " + jsonElement + ". Should be object.");
+
+      String returnType = getFieldAsString(
+          jsonObject, "returnType",
+          "Invalid JSON function signature: " + jsonElement
+              + ". Field returnType should be string.");
+
+      Type parsedReturnType = parseType(returnType);
+
+      FunctionArgumentType[] arguments = Optional.ofNullable(jsonObject.get("arguments"))
+          .map(jsonArguments -> context.deserialize(jsonArguments, FunctionArgumentType[].class))
+          .map(FunctionArgumentType[].class::cast)
+          .orElseThrow(() -> new JsonParseException(
+              "Invalid JSON function signature: " + jsonElement + ". Arguments missing."));
+
+      return new FunctionSignature(
+          new FunctionArgumentType(parsedReturnType),
+          Arrays.asList(arguments),
+          -1);
+
+    }
+  }
+
+  /**
+   * Gson deserializer for {@link FunctionArgumentType}
+   */
+  private static class FunctionArgumentTypeDeserializer
+      implements JsonDeserializer<FunctionArgumentType> {
+
+    @Override
+    public FunctionArgumentType deserialize(
+        JsonElement jsonElement,
+        java.lang.reflect.Type type,
+        JsonDeserializationContext context
+    ) throws JsonParseException {
+      JsonObject jsonObject = getAsJsonObject(
+          jsonElement,
+          "Invalid JSON function argument: " + jsonElement + ". Should be object.");
+
+      String argumentName = getFieldAsString(
+          jsonObject, "name",
+          "Invalid JSON function argument: " + jsonElement + ". Field name should be string.");
+
+      String argumentType = getFieldAsString(
+          jsonObject, "type",
+          "Invalid JSON function argument: " + jsonElement + ". Field type should be string.");
+
+      Type parsedArgumentType = parseType(argumentType);
+
+      return new FunctionArgumentType(
+          parsedArgumentType,
+          FunctionArgumentTypeOptions.builder()
+              .setArgumentName(argumentName, NamedArgumentKind.POSITIONAL_OR_NAMED)
+              .build(),
+          1
+      );
+    }
+  }
+
+  /**
+   * Gson deserializer for {@link TVFInfo}
+   */
+  private static class TVFDeserializer implements JsonDeserializer<TVFInfo> {
+
+    @Override
+    public TVFInfo deserialize(
+        JsonElement jsonElement,
+        java.lang.reflect.Type type,
+        JsonDeserializationContext context
+    ) throws JsonParseException {
+      JsonObject jsonObject = getAsJsonObject(
+          jsonElement,
+          "Invalid JSON TVF: " + jsonElement + ". TVFs should be objects.");
+
+      String functionName = getFieldAsString(
+          jsonObject, "name",
+          "Invalid JSON TVF: " + jsonElement + ". Field name should be string.");
+
+      FunctionArgumentType[] arguments = Optional.ofNullable(jsonObject.get("arguments"))
+          .map(jsonArguments -> context.deserialize(jsonArguments, FunctionArgumentType[].class))
+          .map(FunctionArgumentType[].class::cast)
+          .orElseThrow(() -> new JsonParseException(
+              "Invalid JSON TVF: " + jsonElement + ". Arguments missing."));
+
+      JsonArray outputColumns = getFieldAsJsonArray(
+          jsonObject, "outputColumns",
+          "Invalid JSON TVF: " + jsonElement + ". Field outputColumns should be array of columns.");
+
+      List<TVFRelation.Column> parsedOutputColumns = outputColumns
+          .asList()
+          .stream()
+          .map(jsonColumn ->
+              getAsJsonObject(jsonColumn,
+                  "Invalid JSON column " + jsonColumn + ". Should be JSON object."))
+          .map(JsonCatalogDeserializer::deserializeTVFOutputColumn)
+          .collect(Collectors.toList());
+
+      FunctionArgumentType returnType =
+          new FunctionArgumentType(
+              SignatureArgumentKind.ARG_TYPE_RELATION,
+              FunctionArgumentTypeOptions.builder().build(),
+              1);
+
+      return TVFInfo.newBuilder()
+          .setNamePath(ImmutableList.of(functionName))
+          .setSignature(new FunctionSignature(returnType, Arrays.asList(arguments), -1))
+          .setOutputSchema(TVFRelation.createColumnBased(parsedOutputColumns))
+          .build();
+    }
+  }
+
+  /**
+   * Gson deserializer for {@link ProcedureInfo}
+   */
+  private static class ProcedureDeserializer implements JsonDeserializer<ProcedureInfo> {
+
+    @Override
+    public ProcedureInfo deserialize(
+        JsonElement jsonElement,
+        java.lang.reflect.Type type,
+        JsonDeserializationContext context
+    ) throws JsonParseException {
+      JsonObject jsonObject = getAsJsonObject(
+          jsonElement,
+          "Invalid JSON procedure: " + jsonElement + ". Preceduress should be objects.");
+
+      String procedureName = getFieldAsString(
+          jsonObject, "name",
+          "Invalid JSON procedure: " + jsonElement + ". Field name should be string.");
+
+      FunctionArgumentType[] arguments = Optional.ofNullable(jsonObject.get("arguments"))
+          .map(jsonArguments -> context.deserialize(jsonArguments, FunctionArgumentType[].class))
+          .map(FunctionArgumentType[].class::cast)
+          .orElseThrow(() -> new JsonParseException(
+              "Invalid JSON procedure: " + jsonElement + ". Arguments missing."));
+
+      FunctionArgumentType returnType =
+          new FunctionArgumentType(TypeFactory.createSimpleType(TypeKind.TYPE_STRING));
+
+      FunctionSignature signature = new FunctionSignature(
+          returnType, Arrays.asList(arguments), -1);
+
+      return new ProcedureInfo(ImmutableList.of(procedureName), signature);
+    }
+  }
+
+}

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AddResourcesToBigQueryCatalog.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AddResourcesToBigQueryCatalog.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class AddResourcesToBigQueryCatalog {
 
   public static void main(String[] args) {
-    BigQueryCatalog catalog = new BigQueryCatalog("bigquery-public-data");
+    BigQueryCatalog catalog = BigQueryCatalog.usingBigQueryAPI("bigquery-public-data");
 
     // Add a table or a set of tables by name
     // Views are considered tables as well, so they can be added this way to the catalog

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AddResourcesToSpannerCatalog.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AddResourcesToSpannerCatalog.java
@@ -22,7 +22,8 @@ import java.util.List;
 public class AddResourcesToSpannerCatalog {
 
   public static void main(String[] args) {
-    SpannerCatalog catalog = new SpannerCatalog("projectId", "instance", "database");
+    SpannerCatalog catalog = SpannerCatalog.usingSpannerClient(
+        "projectId", "instance", "database");
 
     // Add a table or a set of tables by name
     // Views are considered tables as well, so they can be added this way to the catalog

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeBigQuery.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeBigQuery.java
@@ -16,16 +16,7 @@
 
 package com.google.zetasql.toolkit.examples;
 
-import com.google.common.collect.ImmutableList;
 import com.google.zetasql.AnalyzerOptions;
-import com.google.zetasql.Constant;
-import com.google.zetasql.SimpleConstantProtos.SimpleConstantProto;
-import com.google.zetasql.TypeFactory;
-import com.google.zetasql.ZetaSQLType.TypeKind;
-import com.google.zetasql.ZetaSQLType.TypeProto;
-import com.google.zetasql.parser.ASTNodes.ASTStatement;
-import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedLiteral;
-import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
 import com.google.zetasql.toolkit.AnalyzedStatement;
 import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
@@ -52,7 +43,7 @@ public class AnalyzeBigQuery {
     // resources.
     // You can also provide your own BigQuery API client or a custom implementation of
     // BigQueryResourceProvider.
-    BigQueryCatalog catalog = new BigQueryCatalog("bigquery-public-data");
+    BigQueryCatalog catalog = BigQueryCatalog.usingBigQueryAPI("bigquery-public-data");
 
     // Step 2: Add tables to the catalog before analyzing
     // BigQueryCatalog.addTable will fetch the table metadata and

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeCloudSpanner.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzeCloudSpanner.java
@@ -39,8 +39,8 @@ public class AnalyzeCloudSpanner {
     // This will use application default credentials to create a Spanner DatabaseClient.
     // You can also provide your own DatabaseClient or a custom implementation
     // of SpannerResourceProvider.
-    SpannerCatalog catalog =
-        new SpannerCatalog(spannerProjectId, spannerInstanceName, spannerDatabaseName);
+    SpannerCatalog catalog = SpannerCatalog.usingSpannerClient(
+        spannerProjectId, spannerInstanceName, spannerDatabaseName);
 
     // Step 3: Add your tables to the catalog
     // In this case, we add all the tables in the database.

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzingCreateStatements.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/AnalyzingCreateStatements.java
@@ -40,7 +40,7 @@ public class AnalyzingCreateStatements {
             + "CREATE PROCEDURE `dataset.procedure_name`()\nBEGIN\n\nEND;\n"
             + "CALL `dataset.procedure_name`();";
 
-    BigQueryCatalog catalog = new BigQueryCatalog("bigquery-public-data");
+    BigQueryCatalog catalog = BigQueryCatalog.usingBigQueryAPI("bigquery-public-data");
 
     AnalyzerOptions options = new AnalyzerOptions();
     options.setLanguageOptions(BigQueryLanguageOptions.get());

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/LoadTablesUsedInQuery.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/LoadTablesUsedInQuery.java
@@ -35,7 +35,7 @@ public class LoadTablesUsedInQuery {
         "INSERT INTO `bigquery-public-data.samples.wikipedia` (title) VALUES ('random title');\n"
             + "SELECT * FROM `bigquery-public-data.samples.wikipedia` WHERE title = 'random title';";
 
-    BigQueryCatalog catalog = new BigQueryCatalog("bigquery-public-data");
+    BigQueryCatalog catalog = BigQueryCatalog.usingBigQueryAPI("bigquery-public-data");
 
     AnalyzerOptions options = new AnalyzerOptions();
     options.setLanguageOptions(BigQueryLanguageOptions.get());

--- a/zetasql-toolkit-spanner/src/main/java/com/google/zetasql/toolkit/catalog/spanner/LocalSpannerResourceProvider.java
+++ b/zetasql-toolkit-spanner/src/main/java/com/google/zetasql/toolkit/catalog/spanner/LocalSpannerResourceProvider.java
@@ -1,0 +1,33 @@
+package com.google.zetasql.toolkit.catalog.spanner;
+
+import com.google.zetasql.SimpleTable;
+import com.google.zetasql.toolkit.catalog.io.CatalogResources;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * {@link SpannerResourceProvider} implementation that fetches tables from a local
+ * {@link CatalogResources} object.
+ */
+public class LocalSpannerResourceProvider implements SpannerResourceProvider {
+
+  private final CatalogResources catalogResources;
+
+  public LocalSpannerResourceProvider(CatalogResources catalogResources) {
+    this.catalogResources = catalogResources;
+  }
+
+  @Override
+  public List<SimpleTable> getTables(List<String> tableNames) {
+    return catalogResources.getTables()
+        .stream()
+        .filter(table -> tableNames.contains(table.getName()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<SimpleTable> getAllTablesInDatabase() {
+    return catalogResources.getTables();
+  }
+
+}

--- a/zetasql-toolkit-spanner/src/test/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalogTest.java
+++ b/zetasql-toolkit-spanner/src/test/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalogTest.java
@@ -61,7 +61,7 @@ public class SpannerCatalogTest {
   @BeforeEach
   void init() {
     this.spannerCatalog =
-        new SpannerCatalog("project", "instance", "database", spannerResourceProviderMock);
+        new SpannerCatalog(spannerResourceProviderMock);
   }
 
   private Table assertTableExistsInCatalog(SpannerCatalog catalog, SimpleTable table) {


### PR DESCRIPTION
Adds support for creating catalog that use resources defined in a JSON object. This is primarily intended for testing purposes, so that users don't need to write their own `[BigQuery/Spanner]ResourceProvider` for simple testing.

It achieves it by:
* Introducing the `CatalogResources` dataclass and a way to deserialize from a JSON object
* Creates resource provider implementations for both BigQuery and Spanner that use a `CatalogResources` object

Example:
``` java
String json = "{\n"
    + "  \"tables\": ["
    + "    {"
    + "      \"name\": \"projectId.dataset.table\","
    + "      \"columns\": ["
    + "        { \"name\": \"column\", \"type\": \"INT64\" },"
    + "        { \"name\": \"column2\", \"type\": \"TIMESTAMP\", \"isPseudoColumn\": true }"
    + "      ]"
    + "    }"
    + "  ]"
    + "}";
CatalogResources resources = CatalogResources.fromJson(json);
BigQueryCatalog catalog = BigQueryCatalog.usingResources("projectId", resources);
```