### PR TITLE
Extract column level lineage for SELECT statement

### DIFF
--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/tools/lineage/ColumnLineageExtractor.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/tools/lineage/ColumnLineageExtractor.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.zetasql.Table;
 import com.google.zetasql.Type;
 import com.google.zetasql.resolvedast.ResolvedColumn;
+import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedQueryStmt;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedColumnRef;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedCreateTableAsSelectStmt;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedCreateViewBase;
@@ -147,6 +148,19 @@ public class ColumnLineageExtractor {
 
     return extractColumnLevelLineageForOutputColumns(
         fullViewName, outputColumns, createViewBase);
+  }
+
+  /**
+   * Extracts the column-level lineage entries for a {@link ResolvedQueryStmt} statement
+   *
+   * @param statement The ResolvedQueryStmt statement for which to extract lineage
+   * @param outputTable The name of the table the statement write to
+   * @return The set of resulting {@link ColumnLineage} objects
+   */
+  public static Set<ColumnLineage> extractColumnLevelLineage(
+      ResolvedQueryStmt statement, String outputTable) {
+    List<ResolvedOutputColumn> outputColumns = statement.getOutputColumnList();
+    return extractColumnLevelLineageForOutputColumns(outputTable, outputColumns, statement);
   }
 
   /**

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/tools/lineage/ParentColumnFinder.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/tools/lineage/ParentColumnFinder.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
  * those scopes to correlate the ResolvedWithRefScan columns to their parents in the corresponding
  * ResolvedWithEntry.
  */
-class ParentColumnFinder extends Visitor {
+public class ParentColumnFinder extends Visitor {
 
   private final HashMap<String, List<ResolvedColumn>> columnsToParents = new HashMap<>();
   private final Set<String> terminalColumns = new HashSet<>();


### PR DESCRIPTION
Related to #28 

Changes:
1. Added extractColumnLevelLineage for extracting ResolvedQueryStmt statement in ColumnLineageExtractor.
2. Changed the access modifier of ParentColumnFinder to public, allowing it to be accessed from other classes outside of this package.