### PR TITLE
Add reflection-based patching of GRPC's default max nesting depth

### DIFF
--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/tools/patch/ZetaSQLPatcher.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/tools/patch/ZetaSQLPatcher.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.tools.patch;
+
+import com.google.protobuf.ExperimentalApi;
+import com.google.protobuf.Message;
+import com.google.zetasql.LocalService.AnalyzeRequest;
+import com.google.zetasql.LocalService.AnalyzeResponse;
+import com.google.zetasql.LocalService.BuildSqlRequest;
+import com.google.zetasql.LocalService.BuildSqlResponse;
+import com.google.zetasql.LocalService.ParseRequest;
+import com.google.zetasql.LocalService.ParseResponse;
+import com.google.zetasql.ZetaSqlLocalServiceGrpc;
+import com.google.zetasql.io.grpc.MethodDescriptor;
+import com.google.zetasql.io.grpc.MethodDescriptor.Marshaller;
+import com.google.zetasql.io.grpc.protobuf.ProtoUtils;
+import java.lang.reflect.Field;
+
+/**
+ * Implements some reflection-based patches to ZetaSQL. The only patch currently available is
+ * {@link #patchMaxProtobufNestingDepth(int)}.
+ *
+ * <p> These reflection-based patches are brittle by design and should be avoided whenever possible.
+ */
+public class ZetaSQLPatcher {
+
+  /**
+   * Patches the maximum protobuf nesting depth allowed when accessing the ZetaSQL local service
+   * through GRPC. This patch should be applied when working with large SQL statements that
+   * hit GRPC's default nesting limit of 100.
+   *
+   * <p> This new max depth is only set for three key RPCs, which result in a lot of nesting when
+   * working with large SQL statements. These RPCs are Parse, Analyze and BuildSql.
+   *
+   * <p> This patch should be considered experimental; as it relies on
+   * {@link ProtoUtils#marshallerWithRecursionLimit(Message, int)} from grpc-java, which is
+   * experimental itself.
+   *
+   * @param maxDepth the maximum nesting depth to set for RPCs to the ZetaSQL local service.
+   *  Should be greater than 100.
+   * @throws IllegalAccessException if any reflective access performed by this patch produces an
+   *  illegal access.
+   */
+  @ExperimentalApi
+  public static void patchMaxProtobufNestingDepth(int maxDepth)
+      throws IllegalAccessException {
+    if (!(maxDepth > 100)) {
+      throw new IllegalArgumentException(
+          "Invalid max nesting depth for patching protobuf. Should be at least 100, but got: "
+              + maxDepth);
+    }
+
+    patchMaxNestingDepthForParse(maxDepth);
+    patchMaxNestingDepthForAnalyze(maxDepth);
+    patchMaxNestingDepthForBuildSql(maxDepth);
+  }
+
+  private static Field getLocalServiceField(String name) {
+    try {
+      return ZetaSqlLocalServiceGrpc.class.getDeclaredField(name);
+    } catch (NoSuchFieldException noSuchFieldException) {
+      throw new IllegalStateException(
+          "Tried to access not existent field in class ZetaSqlLocalServiceGrpc: " + name,
+          noSuchFieldException);
+    }
+  }
+
+  private static void patchMaxNestingDepthForAnalyze(int maxDepth)
+      throws IllegalAccessException {
+    Field getAnalyzeMethod = getLocalServiceField("getAnalyzeMethod");
+
+    Marshaller<AnalyzeRequest> requestMarshaller = ProtoUtils.marshallerWithRecursionLimit(
+        AnalyzeRequest.getDefaultInstance(), maxDepth);
+    Marshaller<AnalyzeResponse> responseMarshaller = ProtoUtils.marshallerWithRecursionLimit(
+        AnalyzeResponse.getDefaultInstance(), maxDepth);
+
+    MethodDescriptor<AnalyzeRequest, AnalyzeResponse> newMethodDescriptor =
+        ZetaSqlLocalServiceGrpc.getAnalyzeMethod()
+            .toBuilder(requestMarshaller, responseMarshaller)
+            .build();
+
+    synchronized (ZetaSqlLocalServiceGrpc.class) {
+      getAnalyzeMethod.setAccessible(true);
+      getAnalyzeMethod.set(null, newMethodDescriptor);
+    }
+  }
+
+  private static void patchMaxNestingDepthForParse(int maxDepth)
+      throws IllegalAccessException {
+    Field getParseMethod = getLocalServiceField("getParseMethod");
+
+    Marshaller<ParseRequest> requestMarshaller = ProtoUtils.marshallerWithRecursionLimit(
+        ParseRequest.getDefaultInstance(), maxDepth);
+    Marshaller<ParseResponse> responseMarshaller = ProtoUtils.marshallerWithRecursionLimit(
+        ParseResponse.getDefaultInstance(), maxDepth);
+
+    MethodDescriptor<ParseRequest, ParseResponse> newMethodDescriptor =
+        ZetaSqlLocalServiceGrpc.getParseMethod()
+            .toBuilder(requestMarshaller, responseMarshaller)
+            .build();
+
+    synchronized (ZetaSqlLocalServiceGrpc.class) {
+      getParseMethod.setAccessible(true);
+      getParseMethod.set(null, newMethodDescriptor);
+    }
+  }
+
+  private static void patchMaxNestingDepthForBuildSql(int maxDepth)
+      throws IllegalAccessException {
+    Field getBuildSqlMethod = getLocalServiceField("getBuildSqlMethod");
+
+    Marshaller<BuildSqlRequest> requestMarshaller = ProtoUtils.marshallerWithRecursionLimit(
+        BuildSqlRequest.getDefaultInstance(), maxDepth);
+    Marshaller<BuildSqlResponse> responseMarshaller = ProtoUtils.marshallerWithRecursionLimit(
+        BuildSqlResponse.getDefaultInstance(), maxDepth);
+
+    MethodDescriptor<BuildSqlRequest, BuildSqlResponse> newMethodDescriptor =
+        ZetaSqlLocalServiceGrpc.getBuildSqlMethod()
+            .toBuilder(requestMarshaller, responseMarshaller)
+            .build();
+
+    synchronized (ZetaSqlLocalServiceGrpc.class) {
+      getBuildSqlMethod.setAccessible(true);
+      getBuildSqlMethod.set(null, newMethodDescriptor);
+    }
+  }
+
+}

--- a/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/tools/patch/ZetaSQLPatcherTest.java
+++ b/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/tools/patch/ZetaSQLPatcherTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.tools.patch;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.zetasql.AnalyzerOptions;
+import com.google.zetasql.Parser;
+import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ZetaSQLPatcherTest {
+
+  private ZetaSQLToolkitAnalyzer analyzer;
+
+  @BeforeEach
+  void init() {
+    AnalyzerOptions analyzerOptions = new AnalyzerOptions();
+    analyzerOptions.getLanguageOptions().enableMaximumLanguageFeatures();
+    analyzerOptions.getLanguageOptions().setSupportsAllStatementKinds();
+
+    this.analyzer = new ZetaSQLToolkitAnalyzer(analyzerOptions);
+  }
+
+  public static String generateNestedSelectStatement(int times) {
+    if (times == 1) {
+      return "SELECT 1";
+    }
+
+    return String.format("SELECT 1 FROM (%s)", generateNestedSelectStatement(times - 1));
+  }
+  @Test
+  void testMaxNestingDepthPatch() {
+    // The query is a SELECT statement nested 100 times. Parsing or analyzing
+    // such a statement normally fails due to reaching the default max nesting
+    // depth in the ZetaSQL local service.
+    // After patching the max nesting depth, it should not fail.
+    String query = generateNestedSelectStatement(100);
+
+    try {
+      ZetaSQLPatcher.patchMaxProtobufNestingDepth(1000);
+    } catch (IllegalAccessException err) {
+      Assumptions.abort("Aborting test because the patch was not applied successfully due to "
+          + "disallowed reflective access.");
+    }
+
+    assertDoesNotThrow(() -> {
+      this.analyzer.analyzeStatements(query).next();
+    });
+  }
+
+}


### PR DESCRIPTION
ZetaSQL's Java API uses a GRPC service to call into the actual C++ implementation of ZetaSQL. By default, the serialization logic of that communication allows for a nesting depth in protobuf messages of up to 100. However, long queries can exceed that level of nesting and as a result cannot be analyzed by default.

This implements a reflection-based patch that allows users to override that limit to a greater number. This is brittle by design and should be used with caution.

Fixes #31