### PR TITLE
Update GH actions to build and test on JDK 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,7 @@ updates:
   schedule:
     interval: daily
   ignore:
+    # Ignore dependencies which no longer support JDK 8 in their latest release
     - dependency-name: org.mockito:*
     - dependency-name: com.diffplug.spotless:*
+    - dependency-name: org.antlr:*

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,16 +25,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 8
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '8'
         distribution: 'temurin'
         cache: maven
     - name: Build
       run: mvn --batch-mode clean compile
     - name: Test
-      run: mvn --batch-mode test -Dmaven.test.skip=false
+      run: mvn --batch-mode verify -Dmaven.test.skip=false
     - name: Update dependency graph
       if: github.ref == 'refs/heads/main'
       uses: advanced-security/maven-dependency-submission-action@v4

--- a/zetasql-toolkit-core/pom.xml
+++ b/zetasql-toolkit-core/pom.xml
@@ -36,7 +36,7 @@
     <zetasql.toolkit.version>${project.version}</zetasql.toolkit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.deploy.skip>false</maven.deploy.skip>
-    <antlr4.version>4.13.1</antlr4.version>
+    <antlr4.version>4.9.3</antlr4.version>
     <properties.maven.plugin.version>1.2.1</properties.maven.plugin.version>
     <maven.jar.plugin.version>3.4.1</maven.jar.plugin.version>
   </properties>


### PR DESCRIPTION
* Updates GitHub actions to build and test on JDK 8.
* Rolls back a dependabot ANTLR4 upgrade that broke Java 8. Should not happen again, now that tests run on JDK 8.
* Excludes ANTLR4 from dependabot version updates.