### PR TITLE
Add SharedTableMigration tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <maven.gpg.plugin.version>3.2.4</maven.gpg.plugin.version>
     <maven.surefire.version>3.3.0</maven.surefire.version>
     <spotless.version>2.30.0</spotless.version>
+    <google.cloud.jib.version>3.4.2</google.cloud.jib.version>
   </properties>
 
   <dependencyManagement>
@@ -204,6 +205,14 @@
               <importOrder/>
               <removeUnusedImports/>
             </java>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>com.google.cloud.tools</groupId>
+          <artifactId>jib-maven-plugin</artifactId>
+          <version>${google.cloud.jib.version}</version>
+          <configuration>
+            <skip>true</skip>
           </configuration>
         </plugin>
       </plugins>

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryReference.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryReference.java
@@ -27,11 +27,11 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 /** Dataclass representing a reference to a BigQuery resource. */
-class BigQueryReference {
+public class BigQueryReference {
 
   private static final Pattern PROJECT_PATTERN = Pattern.compile("[a-zA-Z0-9\\.\\-\\:]+");
   private static final Pattern DATASET_PATTERN = Pattern.compile("[a-zA-Z0-9\\_]+");
-  private static final Pattern RESOURCE_PATTERN = Pattern.compile("[a-zA-Z0-9\\_-]+");
+  private static final Pattern RESOURCE_PATTERN = Pattern.compile("[a-zA-Z0-9\\_-]+\\*?");
   private final String projectId;
   private final String datasetId;
   private final String resourceName;

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/tools/migration/ShardedTableMigrator.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/tools/migration/ShardedTableMigrator.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.tools.migration;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.zetasql.Parser;
+import com.google.zetasql.SqlFormatter;
+import com.google.zetasql.parser.ASTNode;
+import com.google.zetasql.parser.ASTNodes.ASTFromClause;
+import com.google.zetasql.parser.ASTNodes.ASTIdentifier;
+import com.google.zetasql.parser.ASTNodes.ASTJoin;
+import com.google.zetasql.parser.ASTNodes.ASTPathExpression;
+import com.google.zetasql.parser.ASTNodes.ASTScript;
+import com.google.zetasql.parser.ASTNodes.ASTSelect;
+import com.google.zetasql.parser.ASTNodes.ASTTVF;
+import com.google.zetasql.parser.ASTNodes.ASTTablePathExpression;
+import com.google.zetasql.parser.ASTNodes.ASTTableSubquery;
+import com.google.zetasql.parser.ASTNodes.ASTWhereClause;
+import com.google.zetasql.parser.ParseTreeVisitor;
+import com.google.zetasql.toolkit.ParseTreeUtils;
+import com.google.zetasql.toolkit.StatementRewriter;
+import com.google.zetasql.toolkit.StatementRewriter.Rewrite;
+import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Tool for migrating BigQuery jobs away from date-sharded tables to partitioned tables. This tool
+ * automatically rewrites queries that use table wildcards and _TABLE_SUFFIX to use the new
+ * partitioned tables. Only SELECT statements are currently rewritten.
+ *
+ * <p> This tool currently makes the following assumptions about the migration:
+ * <ul>
+ *   <li> The original sharded tables use the format `table_YYYYMMDD`
+ *   <li> The new tables use the same names as the shared tables, but drop the `_YYYYMMDD` suffix
+ *   <li> All partitioned tables have been created already (i.e. no incremental migration of
+ *        queries for now)
+ *   <li> All wildcard table references will follow one of these formats:
+ *   <ul>
+ *     <li> `[project].dataset.table_name_YYYYMMDD`
+ *     <li> `[project].dataset.table_name_YYYYMM*`
+ *     <li> `[project].dataset.table_name_YYYY*`
+ *     <li> `[project].dataset.table_name_*`
+ *   </ul>
+ * </ul>
+ *
+ * <p> When migrating a SQL script, this tool will:
+ * <ol>
+ *   <li> Find all SELECT statements or expressions
+ *   <li> Drop the wildcard or date-sharded suffix from table references (e.g. `table_*`,
+ *        `table_20240517` and `table_2024*` all become `table`)
+ *   <li> Replace references to _TABLE_SUFFIX with an equivalent expression like
+ *        FORMAT_DATE("...", [PARTITION_COLUMN])
+ *   <li> Add required WHERE condition filters to achieve the same results from queries (e.g.
+ *        a query on `table_20240517` will be translated to a query on `table` with the condition
+ *        DATE([PARTITION_COLUMN]) = '2024-05-17' added to the WHERE clause)
+ * </ol>
+ */
+public class ShardedTableMigrator {
+
+  private static Rewrite createRewrite(int from, int to, String content) {
+    return new Rewrite(from, to, content);
+  }
+
+  private static Rewrite createRewrite(ASTNode node, String content) {
+    return new Rewrite(
+        node.getParseLocationRange().start(),
+        node.getParseLocationRange().end(),
+        content);
+  }
+
+  /**
+   * Finds all tables referenced in an {@link ASTSelect}. Does not recurse into subqueries.
+   *
+   * @param select The ASTSelect to get _TABLE_SUFFIX references from
+   * @return The list of {@link ASTTablePathExpression} referenced in the provided ASTSelect
+   */
+  private static List<ASTTablePathExpression> findTableExpressions(ASTSelect select) {
+    ArrayList<ASTTablePathExpression> result = new ArrayList<>();
+
+    select.accept(new ParseTreeVisitor() {
+      public void visit(ASTTVF tvf) {}
+      public void visit(ASTTableSubquery subquery) {}
+      public void visit(ASTJoin join) {
+        join.getLhs().accept(this);
+        join.getRhs().accept(this);
+      }
+      public void visit(ASTTablePathExpression tablePathExpression) {
+        if (Objects.nonNull(tablePathExpression.getPathExpr())) {
+          result.add(tablePathExpression);
+        }
+      }
+    });
+
+    return result;
+  }
+
+  /**
+   * Finds all references to _TABLE_SUFFIX in as {@link ASTSelect} that come from a specific table
+   * given its alias. If withAlias is present, it will return all expressions in the shape
+   * "[alias]._TABLE_SUFFIX". If withAlias is not present, it will return all expressions in the
+   * shape "_TABLE_SUFFIX".
+   *
+   * <p> Does not recurse into subqueries
+   *
+   * @param select The ASTSelect to get _TABLE_SUFFIX references from
+   * @param withAlias Optionally, the alias the table we're looking for has
+   * @return The references to _TABLE_SUFFIX
+   */
+  private static List<ASTPathExpression> findTableSuffixReferences(
+      ASTSelect select,
+      Optional<String> withAlias) {
+    ArrayList<ASTPathExpression> result = new ArrayList<>();
+
+    select.accept(new ParseTreeVisitor() {
+      public void visit(ASTTVF tvf) {}
+      public void visit(ASTTableSubquery subquery) {}
+      public void visit(ASTPathExpression pathExpression) {
+        List<ASTIdentifier> names = pathExpression.getNames();
+        String lastNamePathElement = names.get(names.size() - 1).getIdString();
+
+        if (!lastNamePathElement.equalsIgnoreCase("_TABLE_SUFFIX")) {
+          return;
+        }
+
+        if (!withAlias.isPresent() && names.size() == 1) {
+          result.add(pathExpression);
+        } else if (
+            withAlias.isPresent()
+                && names.size() == 2
+                && names.get(0).getIdString().equalsIgnoreCase(withAlias.get())) {
+          result.add(pathExpression);
+        }
+      }
+    });
+
+    return result;
+  }
+
+  /**
+   * Returns the list of {@link StatementRewriter.Rewrite}s that replace references to sharded
+   * tables in an {@link ASTSelect} with their corresponding partitioned columns by dropping
+   * the `_YYYYMMDD` suffix
+   *
+   * @param referencedWildcardTables The sharded tables the ASTSelect references
+   * @return The list of Rewrites that need to be applied the original query
+   */
+  private static List<Rewrite> replaceWildcardTableReferences(
+      List<WildcardTable> referencedWildcardTables) {
+    return referencedWildcardTables.stream()
+        .map(wildcardTable -> createRewrite(
+            wildcardTable.parseTreeNode,
+            wildcardTable.getFullNamePrefixQuoted()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Returns the list of {@link StatementRewriter.Rewrite}s that replace references to _TABLE_SUFFIX
+   * in an {@link ASTSelect} with equivalent expressions based on the partition column.
+   *
+   * @param select The ASTSelect to generate rewrites for
+   * @param referencedWildcardTables The sharded tables the ASTSelect references
+   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their
+   *  time partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map
+   *  should be ("table" -> "PARTITION_COLUMN_NAME")
+   * @return The list of Rewrites that need to be applied to the original query
+   */
+  private static List<Rewrite> replaceTableSuffixReferences(
+      ASTSelect select, List<WildcardTable> referencedWildcardTables,
+      Map<String, String> tablesToPartitionColumns) {
+    ArrayList<Rewrite> rewrites = new ArrayList<>();
+
+    for (WildcardTable referencedWildcardTable : referencedWildcardTables) {
+      String partitionColumn = tablesToPartitionColumns.get(referencedWildcardTable.fullNamePrefix);
+      List<ASTPathExpression> tableSuffixReferences =
+          findTableSuffixReferences(select, referencedWildcardTable.alias);
+
+      if (Objects.isNull(partitionColumn)) {
+        throw new IllegalArgumentException(
+            "Missing partition column for wildcard table " + referencedWildcardTable.fullNamePrefix);
+      }
+
+      for (ASTPathExpression tableSuffixReference : tableSuffixReferences) {
+        String tableSuffixEquivalent =
+            referencedWildcardTable.getTableSuffixEquivalent(partitionColumn);
+        rewrites.add(createRewrite(tableSuffixReference, tableSuffixEquivalent));
+      }
+    }
+
+    return rewrites;
+  }
+
+  /**
+   * Returns the list of {@link StatementRewriter.Rewrite}s that add the required WHERE conditions
+   * to an {@link ASTSelect}, based on the list of sharded tables it queries.
+   *
+   * @param select The ASTSelect to generate rewrites for
+   * @param referencedWildcardTables The sharded tables the ASTSelect references
+   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their
+   *  time partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map
+   *  should be ("table" -> "PARTITION_COLUMN_NAME")
+   * @return The list of Rewrites that need to be applied to the original query
+   */
+  private static List<Rewrite> insertNewWhereFilters(
+      ASTSelect select, List<WildcardTable> referencedWildcardTables,
+      Map<String, String> tablesToPartitionColumns) {
+    List<String> extraWhereClauseExpressions = new ArrayList<>();
+
+    for (WildcardTable referencedWildcardTable : referencedWildcardTables) {
+      String partitionColumn = tablesToPartitionColumns.get(referencedWildcardTable.fullNamePrefix);
+
+      if (Objects.isNull(partitionColumn)) {
+        throw new IllegalArgumentException(
+            "Missing partition column for wildcard table "
+                + referencedWildcardTable.fullNamePrefix);
+      }
+
+      referencedWildcardTable.getEquivalentWhereFilter(partitionColumn)
+          .ifPresent(extraWhereClauseExpressions::add);
+    }
+
+    if (extraWhereClauseExpressions.isEmpty()) {
+      return ImmutableList.of();
+    }
+
+    ArrayList<Rewrite> rewrites = new ArrayList<>();
+    String newWhereClauseExpression =
+        "(" + String.join(" AND ", extraWhereClauseExpressions) + ")";
+    ASTWhereClause whereClause = select.getWhereClause();
+
+    if (Objects.isNull(whereClause)) {
+      // The select had no WHERE clause, so we add "WHERE {newWhereClauseExpression}" after
+      // the FROM clause
+      ASTFromClause fromClause = select.getFromClause();
+      rewrites.add(createRewrite(
+          fromClause.getParseLocationRange().end(),
+          fromClause.getParseLocationRange().end(),
+          " WHERE " + newWhereClauseExpression));
+    } else {
+      // The select already had a WHERE clause. We rewrite "WHERE {previousExpression}" to
+      // "WHERE ({previousExpression}) AND {newWhereClauseExpression}"
+      rewrites.add(createRewrite(
+          whereClause.getParseLocationRange().start() + 5,
+          whereClause.getParseLocationRange().start() + 5,
+          " ("));
+      rewrites.add(createRewrite(
+          whereClause.getParseLocationRange().end(),
+          whereClause.getParseLocationRange().end(),
+          ") AND " + newWhereClauseExpression));
+    }
+
+    return rewrites;
+  }
+
+  /**
+   * Returns the list of {@link StatementRewriter.Rewrite}s that need to be applied to the provided
+   * {@link ASTSelect}.
+   *
+   * @param select The ASTSelect to generate rewrites for
+   * @param projectId The GCP project id this query would be run on
+   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their
+   *  time partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map
+   *  should be ("table" -> "PARTITION_COLUMN_NAME")
+   * @return The list of Rewrites that need to be applied to the original query
+   */
+  private static List<Rewrite> rewriteSelect(
+      ASTSelect select, String projectId, Map<String, String> tablesToPartitionColumns) {
+    List<ASTTablePathExpression> referencedTables = findTableExpressions(select);
+
+    List<WildcardTable> referencedWildcardTables = referencedTables
+        .stream()
+        .map(tablePathExpression -> WildcardTable.tryBuild(projectId, tablePathExpression))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
+
+    ArrayList<Rewrite> rewrites = new ArrayList<>();
+
+    rewrites.addAll(replaceWildcardTableReferences(referencedWildcardTables));
+    rewrites.addAll(replaceTableSuffixReferences(select, referencedWildcardTables, tablesToPartitionColumns));
+    rewrites.addAll(insertNewWhereFilters(select, referencedWildcardTables, tablesToPartitionColumns));
+
+    return rewrites;
+  }
+
+  /**
+   * Rewrites a query to use partitioned tables instead of date-shared tables and _TABLE_SUFFIX. See
+   * this class' javadoc for more information.
+   *
+   * @param query The query to migrate
+   * @param projectId The GCP project id this query would be run on
+   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their
+   *  time partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map
+   *  should be ("table" -> "PARTITION_COLUMN_NAME")
+   * @return The rewritten query
+   */
+  public static String migrate(String query, String projectId, Map<String, String> tablesToPartitionColumns) {
+    ASTScript parsedScript =
+        Parser.parseScript(query, BigQueryLanguageOptions.get());
+
+    List<ASTSelect> selects = ParseTreeUtils.findDescendantSubtreesWithKind(
+        parsedScript, ASTSelect.class);
+
+    List<Rewrite> rewrites = selects.stream()
+        .flatMap(select -> rewriteSelect(select, projectId, tablesToPartitionColumns).stream())
+        .collect(Collectors.toList());
+
+    return StatementRewriter.applyRewrites(query, rewrites);
+  }
+
+}

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/tools/migration/ShardedTableMigrator.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/tools/migration/ShardedTableMigrator.java
@@ -17,9 +17,7 @@
 package com.google.zetasql.toolkit.tools.migration;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.zetasql.Parser;
-import com.google.zetasql.SqlFormatter;
 import com.google.zetasql.parser.ASTNode;
 import com.google.zetasql.parser.ASTNodes.ASTFromClause;
 import com.google.zetasql.parser.ASTNodes.ASTIdentifier;
@@ -36,7 +34,6 @@ import com.google.zetasql.toolkit.ParseTreeUtils;
 import com.google.zetasql.toolkit.StatementRewriter;
 import com.google.zetasql.toolkit.StatementRewriter.Rewrite;
 import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -49,31 +46,33 @@ import java.util.stream.Collectors;
  * automatically rewrites queries that use table wildcards and _TABLE_SUFFIX to use the new
  * partitioned tables. Only SELECT statements are currently rewritten.
  *
- * <p> This tool currently makes the following assumptions about the migration:
+ * <p>This tool currently makes the following assumptions about the migration:
+ *
  * <ul>
- *   <li> The original sharded tables use the format `table_YYYYMMDD`
- *   <li> The new tables use the same names as the shared tables, but drop the `_YYYYMMDD` suffix
- *   <li> All partitioned tables have been created already (i.e. no incremental migration of
- *        queries for now)
- *   <li> All wildcard table references will follow one of these formats:
- *   <ul>
- *     <li> `[project].dataset.table_name_YYYYMMDD`
- *     <li> `[project].dataset.table_name_YYYYMM*`
- *     <li> `[project].dataset.table_name_YYYY*`
- *     <li> `[project].dataset.table_name_*`
- *   </ul>
+ *   <li>The original sharded tables use the format `table_YYYYMMDD`
+ *   <li>The new tables use the same names as the shared tables, but drop the `_YYYYMMDD` suffix
+ *   <li>All partitioned tables have been created already (i.e. no incremental migration of queries
+ *       for now)
+ *   <li>All wildcard table references will follow one of these formats:
+ *       <ul>
+ *         <li>`[project].dataset.table_name_YYYYMMDD`
+ *         <li>`[project].dataset.table_name_YYYYMM*`
+ *         <li>`[project].dataset.table_name_YYYY*`
+ *         <li>`[project].dataset.table_name_*`
+ *       </ul>
  * </ul>
  *
- * <p> When migrating a SQL script, this tool will:
+ * <p>When migrating a SQL script, this tool will:
+ *
  * <ol>
- *   <li> Find all SELECT statements or expressions
- *   <li> Drop the wildcard or date-sharded suffix from table references (e.g. `table_*`,
- *        `table_20240517` and `table_2024*` all become `table`)
- *   <li> Replace references to _TABLE_SUFFIX with an equivalent expression like
- *        FORMAT_DATE("...", [PARTITION_COLUMN])
- *   <li> Add required WHERE condition filters to achieve the same results from queries (e.g.
- *        a query on `table_20240517` will be translated to a query on `table` with the condition
- *        DATE([PARTITION_COLUMN]) = '2024-05-17' added to the WHERE clause)
+ *   <li>Find all SELECT statements or expressions
+ *   <li>Drop the wildcard or date-sharded suffix from table references (e.g. `table_*`,
+ *       `table_20240517` and `table_2024*` all become `table`)
+ *   <li>Replace references to _TABLE_SUFFIX with an equivalent expression like FORMAT_DATE("...",
+ *       [PARTITION_COLUMN])
+ *   <li>Add required WHERE condition filters to achieve the same results from queries (e.g. a query
+ *       on `table_20240517` will be translated to a query on `table` with the condition
+ *       DATE([PARTITION_COLUMN]) = '2024-05-17' added to the WHERE clause)
  * </ol>
  */
 public class ShardedTableMigrator {
@@ -84,9 +83,7 @@ public class ShardedTableMigrator {
 
   private static Rewrite createRewrite(ASTNode node, String content) {
     return new Rewrite(
-        node.getParseLocationRange().start(),
-        node.getParseLocationRange().end(),
-        content);
+        node.getParseLocationRange().start(), node.getParseLocationRange().end(), content);
   }
 
   /**
@@ -98,19 +95,23 @@ public class ShardedTableMigrator {
   private static List<ASTTablePathExpression> findTableExpressions(ASTSelect select) {
     ArrayList<ASTTablePathExpression> result = new ArrayList<>();
 
-    select.accept(new ParseTreeVisitor() {
-      public void visit(ASTTVF tvf) {}
-      public void visit(ASTTableSubquery subquery) {}
-      public void visit(ASTJoin join) {
-        join.getLhs().accept(this);
-        join.getRhs().accept(this);
-      }
-      public void visit(ASTTablePathExpression tablePathExpression) {
-        if (Objects.nonNull(tablePathExpression.getPathExpr())) {
-          result.add(tablePathExpression);
-        }
-      }
-    });
+    select.accept(
+        new ParseTreeVisitor() {
+          public void visit(ASTTVF tvf) {}
+
+          public void visit(ASTTableSubquery subquery) {}
+
+          public void visit(ASTJoin join) {
+            join.getLhs().accept(this);
+            join.getRhs().accept(this);
+          }
+
+          public void visit(ASTTablePathExpression tablePathExpression) {
+            if (Objects.nonNull(tablePathExpression.getPathExpr())) {
+              result.add(tablePathExpression);
+            }
+          }
+        });
 
     return result;
   }
@@ -121,46 +122,47 @@ public class ShardedTableMigrator {
    * "[alias]._TABLE_SUFFIX". If withAlias is not present, it will return all expressions in the
    * shape "_TABLE_SUFFIX".
    *
-   * <p> Does not recurse into subqueries
+   * <p>Does not recurse into subqueries
    *
    * @param select The ASTSelect to get _TABLE_SUFFIX references from
    * @param withAlias Optionally, the alias the table we're looking for has
    * @return The references to _TABLE_SUFFIX
    */
   private static List<ASTPathExpression> findTableSuffixReferences(
-      ASTSelect select,
-      Optional<String> withAlias) {
+      ASTSelect select, Optional<String> withAlias) {
     ArrayList<ASTPathExpression> result = new ArrayList<>();
 
-    select.accept(new ParseTreeVisitor() {
-      public void visit(ASTTVF tvf) {}
-      public void visit(ASTTableSubquery subquery) {}
-      public void visit(ASTPathExpression pathExpression) {
-        List<ASTIdentifier> names = pathExpression.getNames();
-        String lastNamePathElement = names.get(names.size() - 1).getIdString();
+    select.accept(
+        new ParseTreeVisitor() {
+          public void visit(ASTTVF tvf) {}
 
-        if (!lastNamePathElement.equalsIgnoreCase("_TABLE_SUFFIX")) {
-          return;
-        }
+          public void visit(ASTTableSubquery subquery) {}
 
-        if (!withAlias.isPresent() && names.size() == 1) {
-          result.add(pathExpression);
-        } else if (
-            withAlias.isPresent()
+          public void visit(ASTPathExpression pathExpression) {
+            List<ASTIdentifier> names = pathExpression.getNames();
+            String lastNamePathElement = names.get(names.size() - 1).getIdString();
+
+            if (!lastNamePathElement.equalsIgnoreCase("_TABLE_SUFFIX")) {
+              return;
+            }
+
+            if (!withAlias.isPresent() && names.size() == 1) {
+              result.add(pathExpression);
+            } else if (withAlias.isPresent()
                 && names.size() == 2
                 && names.get(0).getIdString().equalsIgnoreCase(withAlias.get())) {
-          result.add(pathExpression);
-        }
-      }
-    });
+              result.add(pathExpression);
+            }
+          }
+        });
 
     return result;
   }
 
   /**
    * Returns the list of {@link StatementRewriter.Rewrite}s that replace references to sharded
-   * tables in an {@link ASTSelect} with their corresponding partitioned columns by dropping
-   * the `_YYYYMMDD` suffix
+   * tables in an {@link ASTSelect} with their corresponding partitioned columns by dropping the
+   * `_YYYYMMDD` suffix
    *
    * @param referencedWildcardTables The sharded tables the ASTSelect references
    * @return The list of Rewrites that need to be applied the original query
@@ -168,9 +170,9 @@ public class ShardedTableMigrator {
   private static List<Rewrite> replaceWildcardTableReferences(
       List<WildcardTable> referencedWildcardTables) {
     return referencedWildcardTables.stream()
-        .map(wildcardTable -> createRewrite(
-            wildcardTable.parseTreeNode,
-            wildcardTable.getFullNamePrefixQuoted()))
+        .map(
+            wildcardTable ->
+                createRewrite(wildcardTable.parseTreeNode, wildcardTable.getFullNamePrefixQuoted()))
         .collect(Collectors.toList());
   }
 
@@ -180,13 +182,14 @@ public class ShardedTableMigrator {
    *
    * @param select The ASTSelect to generate rewrites for
    * @param referencedWildcardTables The sharded tables the ASTSelect references
-   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their
-   *  time partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map
-   *  should be ("table" -> "PARTITION_COLUMN_NAME")
+   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their time
+   *     partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map should be
+   *     ("table" -> "PARTITION_COLUMN_NAME")
    * @return The list of Rewrites that need to be applied to the original query
    */
   private static List<Rewrite> replaceTableSuffixReferences(
-      ASTSelect select, List<WildcardTable> referencedWildcardTables,
+      ASTSelect select,
+      List<WildcardTable> referencedWildcardTables,
       Map<String, String> tablesToPartitionColumns) {
     ArrayList<Rewrite> rewrites = new ArrayList<>();
 
@@ -197,7 +200,8 @@ public class ShardedTableMigrator {
 
       if (Objects.isNull(partitionColumn)) {
         throw new IllegalArgumentException(
-            "Missing partition column for wildcard table " + referencedWildcardTable.fullNamePrefix);
+            "Missing partition column for wildcard table "
+                + referencedWildcardTable.fullNamePrefix);
       }
 
       for (ASTPathExpression tableSuffixReference : tableSuffixReferences) {
@@ -216,13 +220,14 @@ public class ShardedTableMigrator {
    *
    * @param select The ASTSelect to generate rewrites for
    * @param referencedWildcardTables The sharded tables the ASTSelect references
-   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their
-   *  time partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map
-   *  should be ("table" -> "PARTITION_COLUMN_NAME")
+   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their time
+   *     partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map should be
+   *     ("table" -> "PARTITION_COLUMN_NAME")
    * @return The list of Rewrites that need to be applied to the original query
    */
   private static List<Rewrite> insertNewWhereFilters(
-      ASTSelect select, List<WildcardTable> referencedWildcardTables,
+      ASTSelect select,
+      List<WildcardTable> referencedWildcardTables,
       Map<String, String> tablesToPartitionColumns) {
     List<String> extraWhereClauseExpressions = new ArrayList<>();
 
@@ -235,7 +240,8 @@ public class ShardedTableMigrator {
                 + referencedWildcardTable.fullNamePrefix);
       }
 
-      referencedWildcardTable.getEquivalentWhereFilter(partitionColumn)
+      referencedWildcardTable
+          .getEquivalentWhereFilter(partitionColumn)
           .ifPresent(extraWhereClauseExpressions::add);
     }
 
@@ -244,29 +250,31 @@ public class ShardedTableMigrator {
     }
 
     ArrayList<Rewrite> rewrites = new ArrayList<>();
-    String newWhereClauseExpression =
-        "(" + String.join(" AND ", extraWhereClauseExpressions) + ")";
+    String newWhereClauseExpression = "(" + String.join(" AND ", extraWhereClauseExpressions) + ")";
     ASTWhereClause whereClause = select.getWhereClause();
 
     if (Objects.isNull(whereClause)) {
       // The select had no WHERE clause, so we add "WHERE {newWhereClauseExpression}" after
       // the FROM clause
       ASTFromClause fromClause = select.getFromClause();
-      rewrites.add(createRewrite(
-          fromClause.getParseLocationRange().end(),
-          fromClause.getParseLocationRange().end(),
-          " WHERE " + newWhereClauseExpression));
+      rewrites.add(
+          createRewrite(
+              fromClause.getParseLocationRange().end(),
+              fromClause.getParseLocationRange().end(),
+              " WHERE " + newWhereClauseExpression));
     } else {
       // The select already had a WHERE clause. We rewrite "WHERE {previousExpression}" to
       // "WHERE ({previousExpression}) AND {newWhereClauseExpression}"
-      rewrites.add(createRewrite(
-          whereClause.getParseLocationRange().start() + 5,
-          whereClause.getParseLocationRange().start() + 5,
-          " ("));
-      rewrites.add(createRewrite(
-          whereClause.getParseLocationRange().end(),
-          whereClause.getParseLocationRange().end(),
-          ") AND " + newWhereClauseExpression));
+      rewrites.add(
+          createRewrite(
+              whereClause.getParseLocationRange().start() + 5,
+              whereClause.getParseLocationRange().start() + 5,
+              " ("));
+      rewrites.add(
+          createRewrite(
+              whereClause.getParseLocationRange().end(),
+              whereClause.getParseLocationRange().end(),
+              ") AND " + newWhereClauseExpression));
     }
 
     return rewrites;
@@ -278,27 +286,29 @@ public class ShardedTableMigrator {
    *
    * @param select The ASTSelect to generate rewrites for
    * @param projectId The GCP project id this query would be run on
-   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their
-   *  time partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map
-   *  should be ("table" -> "PARTITION_COLUMN_NAME")
+   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their time
+   *     partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map should be
+   *     ("table" -> "PARTITION_COLUMN_NAME")
    * @return The list of Rewrites that need to be applied to the original query
    */
   private static List<Rewrite> rewriteSelect(
       ASTSelect select, String projectId, Map<String, String> tablesToPartitionColumns) {
     List<ASTTablePathExpression> referencedTables = findTableExpressions(select);
 
-    List<WildcardTable> referencedWildcardTables = referencedTables
-        .stream()
-        .map(tablePathExpression -> WildcardTable.tryBuild(projectId, tablePathExpression))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(Collectors.toList());
+    List<WildcardTable> referencedWildcardTables =
+        referencedTables.stream()
+            .map(tablePathExpression -> WildcardTable.tryBuild(projectId, tablePathExpression))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
 
     ArrayList<Rewrite> rewrites = new ArrayList<>();
 
     rewrites.addAll(replaceWildcardTableReferences(referencedWildcardTables));
-    rewrites.addAll(replaceTableSuffixReferences(select, referencedWildcardTables, tablesToPartitionColumns));
-    rewrites.addAll(insertNewWhereFilters(select, referencedWildcardTables, tablesToPartitionColumns));
+    rewrites.addAll(
+        replaceTableSuffixReferences(select, referencedWildcardTables, tablesToPartitionColumns));
+    rewrites.addAll(
+        insertNewWhereFilters(select, referencedWildcardTables, tablesToPartitionColumns));
 
     return rewrites;
   }
@@ -309,23 +319,23 @@ public class ShardedTableMigrator {
    *
    * @param query The query to migrate
    * @param projectId The GCP project id this query would be run on
-   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their
-   *  time partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map
-   *  should be ("table" -> "PARTITION_COLUMN_NAME")
+   * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their time
+   *     partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map should be
+   *     ("table" -> "PARTITION_COLUMN_NAME")
    * @return The rewritten query
    */
-  public static String migrate(String query, String projectId, Map<String, String> tablesToPartitionColumns) {
-    ASTScript parsedScript =
-        Parser.parseScript(query, BigQueryLanguageOptions.get());
+  public static String migrate(
+      String query, String projectId, Map<String, String> tablesToPartitionColumns) {
+    ASTScript parsedScript = Parser.parseScript(query, BigQueryLanguageOptions.get());
 
-    List<ASTSelect> selects = ParseTreeUtils.findDescendantSubtreesWithKind(
-        parsedScript, ASTSelect.class);
+    List<ASTSelect> selects =
+        ParseTreeUtils.findDescendantSubtreesWithKind(parsedScript, ASTSelect.class);
 
-    List<Rewrite> rewrites = selects.stream()
-        .flatMap(select -> rewriteSelect(select, projectId, tablesToPartitionColumns).stream())
-        .collect(Collectors.toList());
+    List<Rewrite> rewrites =
+        selects.stream()
+            .flatMap(select -> rewriteSelect(select, projectId, tablesToPartitionColumns).stream())
+            .collect(Collectors.toList());
 
     return StatementRewriter.applyRewrites(query, rewrites);
   }
-
 }

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/tools/migration/ShardedTableMigrator.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/tools/migration/ShardedTableMigrator.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 /**
  * Tool for migrating BigQuery jobs away from date-sharded tables to partitioned tables. This tool
  * automatically rewrites queries that use table wildcards and _TABLE_SUFFIX to use the new
- * partitioned tables. Only SELECT statements are currently rewritten.
+ * partitioned tables. Only SELECT statements and expressions are currently rewritten.
  *
  * <p>This tool currently makes the following assumptions about the migration:
  *
@@ -184,7 +184,7 @@ public class ShardedTableMigrator {
    * @param referencedWildcardTables The sharded tables the ASTSelect references
    * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their time
    *     partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map should be
-   *     ("table" -> "PARTITION_COLUMN_NAME")
+   *     ("table": "PARTITION_COLUMN_NAME", ...)
    * @return The list of Rewrites that need to be applied to the original query
    */
   private static List<Rewrite> replaceTableSuffixReferences(
@@ -222,7 +222,7 @@ public class ShardedTableMigrator {
    * @param referencedWildcardTables The sharded tables the ASTSelect references
    * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their time
    *     partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map should be
-   *     ("table" -> "PARTITION_COLUMN_NAME")
+   *     ("table": "PARTITION_COLUMN_NAME", ...)
    * @return The list of Rewrites that need to be applied to the original query
    */
   private static List<Rewrite> insertNewWhereFilters(
@@ -288,7 +288,7 @@ public class ShardedTableMigrator {
    * @param projectId The GCP project id this query would be run on
    * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their time
    *     partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map should be
-   *     ("table" -> "PARTITION_COLUMN_NAME")
+   *     ("table": "PARTITION_COLUMN_NAME", ...)
    * @return The list of Rewrites that need to be applied to the original query
    */
   private static List<Rewrite> rewriteSelect(
@@ -321,7 +321,7 @@ public class ShardedTableMigrator {
    * @param projectId The GCP project id this query would be run on
    * @param tablesToPartitionColumns A mapping from the names of partitioned tables to their time
    *     partitioning column. E.g. if the only sharded table is `table_YYYYMMDD`, this map should be
-   *     ("table" -> "PARTITION_COLUMN_NAME")
+   *     ("table": "PARTITION_COLUMN_NAME", ...)
    * @return The rewritten query
    */
   public static String migrate(

--- a/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/tools/migration/WildcardTable.java
+++ b/zetasql-toolkit-bigquery/src/main/java/com/google/zetasql/toolkit/tools/migration/WildcardTable.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.tools.migration;
+
+import com.google.zetasql.parser.ASTNodes.ASTAlias;
+import com.google.zetasql.parser.ASTNodes.ASTIdentifier;
+import com.google.zetasql.parser.ASTNodes.ASTPathExpression;
+import com.google.zetasql.parser.ASTNodes.ASTTablePathExpression;
+import com.google.zetasql.toolkit.ParseTreeUtils;
+import com.google.zetasql.toolkit.catalog.bigquery.BigQueryReference;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a wildcard table that was referenced in a query.
+ *
+ * <p> This assumes that all wildcard table names follow the pattern "table_name_YYYYMMDD" and that
+ * references to a wildcard table in a query will match one of these patterns:
+ *
+ * <ul>
+ *   <li> `[project].dataset.table_name_*`
+ *   <li> `[project].dataset.table_name_YYYY*`
+ *   <li> `[project].dataset.table_name_YYYYMM*`
+ *   <li> `[project].dataset.table_name_YYYYMMDD`
+ * </ul>
+ */
+class WildcardTable {
+
+  /**
+   * The full name of the table, with the wildcard prefix removed.
+   *
+   * <p> E.g. "p.d.table_*" and "p.d.table_20240517" both have the prefix "p.d.table".
+   */
+  public final String fullNamePrefix;
+  /**
+   * The {@link Type} of this wildcard table.
+   */
+  public final Type type;
+  /**
+   * The concrete filter used at the end of the wildcard table.
+   *
+   * <p> E.g. "p.d.table_20240517" has the concreteFilter "20240517". "p.d.table_202405*" has
+   * "202405".
+   */
+  public final String concreteFilter;
+  /**
+   * The {@link ASTPathExpression} that references this table.
+   */
+  public final ASTPathExpression parseTreeNode;
+  /**
+   * Optionally, the alias this table was given when referenced.
+   */
+  public final Optional<String> alias;
+
+  /** Use {@link #tryBuild(String, ASTTablePathExpression)} */
+  private WildcardTable(
+      String fullNamePrefix,
+      String concreteFilter,
+      Type type,
+      ASTPathExpression parseTreeNode,
+      Optional<String> alias) {
+    this.fullNamePrefix = fullNamePrefix;
+    this.concreteFilter = concreteFilter;
+    this.type = type;
+    this.parseTreeNode = parseTreeNode;
+    this.alias = alias;
+  }
+
+  public String getFullNamePrefixQuoted() {
+    return String.format("`%s`", this.fullNamePrefix);
+  }
+
+  /**
+   * Returns a filter expression using the partition column that has the same filtering effect
+   * this wildcard reference did. This filter expression should be added to the query's WHERE
+   * clause. Returns an empty optional if no filter should be added.
+   *
+   * <p> E.g. the wildcard table "p.d.table_20240517" will add the filter expression
+   * "DATE([PARTITION_COLUMN]) = '2024-05-17'".
+   *
+   * @param partitionColumnName the name of the partition column for this table
+   * @return The filter expression that should be added to the query's WHERE clause, an empty
+   *  optional if no filter should be added.
+   */
+  public Optional<String> getEquivalentWhereFilter(String partitionColumnName) {
+    Objects.requireNonNull(partitionColumnName);
+
+    String dateColumn = this.alias
+        .map(alias -> String.format("DATE(%s.%s)", alias, partitionColumnName))
+        .orElse(String.format("DATE(%s)", partitionColumnName));
+
+    String filter = null;
+
+    switch (this.type) {
+      case CONCRETE:
+        SimpleDateFormat parser = new SimpleDateFormat("yyyyMMdd");
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        try {
+          String dateExpr = formatter.format(parser.parse(this.concreteFilter));
+          filter = String.format("%s = '%s'", dateColumn, dateExpr);
+        } catch (ParseException err) {
+          // This shouldn't happen, otherwise this wouldn't have been recognized as a CONCRETE
+          // wildcard table.
+          throw new IllegalStateException(
+              "Invalid date filter for CONCRETE wildcard table " + this.concreteFilter, err);
+        }
+        break;
+      case WILDCARD_DAY:
+        filter = String.format(
+            "FORMAT_DATE('%%Y%%m', %s) = '%s'",
+            dateColumn, this.concreteFilter);
+        break;
+      case WILDCARD_MONTH_DAY:
+        filter = String.format(
+            "FORMAT_DATE('%%Y', %s) = '%s'",
+            dateColumn, this.concreteFilter);
+        break;
+      case WILDCARD_DATE:
+        break;
+    }
+
+    return Optional.ofNullable(filter);
+  }
+
+  /**
+   * Returns an expression using the partition column that's equivalent what _TABLE_SUFFIX would
+   * be in this wildcard table.
+   *
+   * <p> E.g. the wildcard table "p.d.table_*" will return the expression
+   *  FORMAT_DATE('%Y%m%d', [PARTITION_COLUMN]).
+   *
+   * @param partitionColumnName the name of the partition column for this table
+   * @return an expression using the partition column that's equivalent to what _TABLE_SUFFIX
+   *  would be in this wildcard table.
+   */
+  public String getTableSuffixEquivalent(String partitionColumnName) {
+    Objects.requireNonNull(partitionColumnName);
+
+    String dateColumn = this.alias
+        .map(alias -> String.format("DATE(%s.%s)", alias, partitionColumnName))
+        .orElse(String.format("DATE(%s)", partitionColumnName));
+
+    String dateFormat = null;
+
+    switch (this.type) {
+      case CONCRETE:
+        throw new IllegalArgumentException("Referenced _TABLE_SUFFIX on a table without wildcard");
+      case WILDCARD_DAY:
+        dateFormat = "%d";
+        break;
+      case WILDCARD_MONTH_DAY:
+        dateFormat = "%m%d";
+        break;
+      case WILDCARD_DATE:
+        dateFormat = "%Y%m%d";
+        break;
+    }
+
+    return String.format("FORMAT_DATE('%s', %s)", dateFormat, dateColumn);
+  }
+
+  /**
+   * Tries to build a WildcardTable based on an {@link ASTTablePathExpression} referencing it
+   * and the GCP project id the query would be run on. Returns an empty optional if this isn't a
+   * reference to a wildcard table.
+   *
+   * @param projectId the GCP project id the query would be run on
+   * @param tablePathExpression the ASTTablePathExpression which potentially references a wildcard
+   *  table
+   * @return The built WildCardTable, an empty optional if this isn't a reference to a wildcard
+   *  table
+   */
+  public static Optional<WildcardTable> tryBuild(
+      String projectId, ASTTablePathExpression tablePathExpression) {
+    ASTPathExpression pathExpression = tablePathExpression.getPathExpr();
+
+    Optional<BigQueryReference> maybeBigQueryReference = Optional.ofNullable(pathExpression)
+        .map(ParseTreeUtils::pathExpressionToString)
+        .filter(BigQueryReference::isQualified)
+        .map(pathName -> BigQueryReference.from(projectId, pathName));
+
+    Optional<Type> maybeType = maybeBigQueryReference
+        .map(BigQueryReference::getResourceName)
+        .flatMap(Type::getType);
+
+    if (!maybeBigQueryReference.isPresent() || !maybeType.isPresent()) {
+      return Optional.empty();
+    }
+
+    BigQueryReference bigQueryReference = maybeBigQueryReference.get();
+    Type type = maybeType.get();
+
+    String tableNamePrefix = type.extractNamePrefix(bigQueryReference.getResourceName());
+    String fullNamePrefix = String.format(
+        "%s.%s.%s",
+        bigQueryReference.getProjectId(), bigQueryReference.getDatasetId(), tableNamePrefix);
+    String concreteFilter = type.extractConcreteFilter(bigQueryReference.getResourceName());
+
+    return Optional.of(new WildcardTable(
+        fullNamePrefix,
+        concreteFilter,
+        type,
+        pathExpression,
+        Optional.ofNullable(tablePathExpression.getAlias())
+            .map(ASTAlias::getIdentifier)
+            .map(ASTIdentifier::getIdString)
+    ));
+  }
+
+  /**
+   * Represents the type of a wildcard table reference. Supported types:
+   *
+   * <ul>
+   *   <li> CONCRETE (`[project].dataset.table_name_YYYYMMDD`)
+   *   <li> WILDCARD_DAY (`[project].dataset.table_name_YYYYMM*`)
+   *   <li> WILDCARD_MONTH_DAY (`[project].dataset.table_name_YYYY*`)
+   *   <li> WILDCARD_DATE (`[project].dataset.table_name_*`)
+   * </ul>
+   */
+  private enum Type {
+    CONCRETE(Pattern.compile("([a-zA-Z0-9\\_-]+)_([0-9]{8})")),
+    WILDCARD_DAY(Pattern.compile("([a-zA-Z0-9\\_-]+)_([0-9]{6})\\*")),
+    WILDCARD_MONTH_DAY(Pattern.compile("([a-zA-Z0-9\\_-]+)_([0-9]{4})\\*")),
+    WILDCARD_DATE(Pattern.compile("([a-zA-Z0-9\\_-]+)_()\\*"));
+
+    public final Pattern pattern;
+
+    Type(Pattern pattern) {
+      this.pattern = pattern;
+    }
+
+    /**
+     * Gets the type of a wildcard table reference based on the name used to reference it.
+     * Returns an empty optional if the name does not follow any of the supported formats.
+     *
+     * @param referenceName the name used to reference the table
+     * @return the type of wildcard table referenced, an empty optional if the name does not follow
+     *  any of the supported formats
+     */
+    public static Optional<Type> getType(String referenceName) {
+      // We need to check in this order, since the patterns conflict with
+      // each other otherwise.
+      Type[] types = {
+          WILDCARD_DATE, WILDCARD_MONTH_DAY, WILDCARD_DAY, CONCRETE
+      };
+      for (Type type : types) {
+        Matcher matcher = type.pattern.matcher(referenceName);
+        if (matcher.find()) {
+          return Optional.of(type);
+        }
+      }
+
+      return Optional.empty();
+    }
+
+    public Matcher match(String referenceName) {
+      Matcher matcher = this.pattern.matcher(referenceName);
+
+      if (!matcher.find()) {
+        throw new IllegalArgumentException(String.format(
+            "Invalid wildcard table %s for type %s",
+            referenceName, this.name()
+        ));
+      }
+
+      return matcher;
+    }
+
+    /**
+     * Extracts the name prefix from the name used to reference a wildcard table of this type.
+     *
+     * <p> E.g. "table_*" and "table_20240517" both have the prefix "table".
+     *
+     * @param referenceName The name used to reference a wildcard table of this type
+     * @return The table's name prefix
+     */
+    public String extractNamePrefix(String referenceName) {
+      return this.match(referenceName).group(1);
+    }
+
+    /**
+     * Extracts the concrete filter applied when referencing a wildcard table of this type from
+     * the name used to reference it
+     *
+     * <p> E.g. "table_20240517" has the concreteFilter "20240517". "table_202405*" has
+     *  "202405".
+     *
+     * @param referenceName The name used to reference a wildcard table of this type
+     * @return The table's concrete filter
+     */
+    public String extractConcreteFilter(String referenceName) {
+      return this.match(referenceName).group(2);
+    }
+  }
+}

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ParseTreeUtils.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ParseTreeUtils.java
@@ -28,24 +28,23 @@ public class ParseTreeUtils {
 
   public static <T> List<T> findDescendantSubtreesWithKind(ASTNode tree, Class<T> kind) {
     List<T> result = new ArrayList<>();
-    tree.accept(new ParseTreeVisitor() {
-      @Override
-      protected void defaultVisit(ASTNode node) {
-        if (kind.isAssignableFrom(node.getClass())) {
-          result.add(kind.cast(node));
-        }
-        super.defaultVisit(node);
-      }
-    });
+    tree.accept(
+        new ParseTreeVisitor() {
+          @Override
+          protected void defaultVisit(ASTNode node) {
+            if (kind.isAssignableFrom(node.getClass())) {
+              result.add(kind.cast(node));
+            }
+            super.defaultVisit(node);
+          }
+        });
 
     return result;
   }
 
   public static String pathExpressionToString(ASTPathExpression pathExpression) {
-    return pathExpression.getNames()
-        .stream()
+    return pathExpression.getNames().stream()
         .map(ASTIdentifier::getIdString)
         .collect(Collectors.joining("."));
   }
-
 }

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ParseTreeUtils.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ParseTreeUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit;
+
+import com.google.zetasql.parser.ASTNode;
+import com.google.zetasql.parser.ASTNodes.ASTIdentifier;
+import com.google.zetasql.parser.ASTNodes.ASTPathExpression;
+import com.google.zetasql.parser.ParseTreeVisitor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ParseTreeUtils {
+
+  public static <T> List<T> findDescendantSubtreesWithKind(ASTNode tree, Class<T> kind) {
+    List<T> result = new ArrayList<>();
+    tree.accept(new ParseTreeVisitor() {
+      @Override
+      protected void defaultVisit(ASTNode node) {
+        if (kind.isAssignableFrom(node.getClass())) {
+          result.add(kind.cast(node));
+        }
+        super.defaultVisit(node);
+      }
+    });
+
+    return result;
+  }
+
+  public static String pathExpressionToString(ASTPathExpression pathExpression) {
+    return pathExpression.getNames()
+        .stream()
+        .map(ASTIdentifier::getIdString)
+        .collect(Collectors.joining("."));
+  }
+
+}

--- a/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/StatementRewriter.java
+++ b/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/StatementRewriter.java
@@ -51,7 +51,6 @@ import com.google.zetasql.parser.ASTNodes.ASTCreateSnapshotTableStatement;
 import com.google.zetasql.parser.ASTNodes.ASTCreateTableStatement;
 import com.google.zetasql.parser.ASTNodes.ASTCreateViewStatement;
 import com.google.zetasql.parser.ASTNodes.ASTDefineTableStatement;
-import com.google.zetasql.parser.ASTNodes.ASTDeleteStatement;
 import com.google.zetasql.parser.ASTNodes.ASTDescribeStatement;
 import com.google.zetasql.parser.ASTNodes.ASTDropAllRowAccessPoliciesStatement;
 import com.google.zetasql.parser.ASTNodes.ASTDropEntityStatement;
@@ -70,9 +69,7 @@ import com.google.zetasql.parser.ASTNodes.ASTForeignKeyReference;
 import com.google.zetasql.parser.ASTNodes.ASTFunctionCall;
 import com.google.zetasql.parser.ASTNodes.ASTFunctionDeclaration;
 import com.google.zetasql.parser.ASTNodes.ASTGrantStatement;
-import com.google.zetasql.parser.ASTNodes.ASTIdentifier;
 import com.google.zetasql.parser.ASTNodes.ASTImportStatement;
-import com.google.zetasql.parser.ASTNodes.ASTInsertStatement;
 import com.google.zetasql.parser.ASTNodes.ASTMergeStatement;
 import com.google.zetasql.parser.ASTNodes.ASTModelClause;
 import com.google.zetasql.parser.ASTNodes.ASTModuleStatement;
@@ -91,7 +88,6 @@ import com.google.zetasql.parser.ASTNodes.ASTTableClause;
 import com.google.zetasql.parser.ASTNodes.ASTTablePathExpression;
 import com.google.zetasql.parser.ASTNodes.ASTTruncateStatement;
 import com.google.zetasql.parser.ASTNodes.ASTUndropStatement;
-import com.google.zetasql.parser.ASTNodes.ASTUpdateStatement;
 import com.google.zetasql.parser.ParseTreeVisitor;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -109,9 +105,9 @@ import java.util.stream.Collectors;
 public class StatementRewriter {
 
   /**
-   * Represents a rewrite that can be applied to a query string. When applied
-   * using {@link #applyRewrites(String, List)}, the StatementRewriter replaces
-   * the substring between index from and to (exclusive) with the content.
+   * Represents a rewrite that can be applied to a query string. When applied using {@link
+   * #applyRewrites(String, List)}, the StatementRewriter replaces the substring between index from
+   * and to (exclusive) with the content.
    */
   public static class Rewrite {
     public final int from;
@@ -135,9 +131,10 @@ public class StatementRewriter {
    */
   public static String applyRewrites(String query, List<Rewrite> rewrites) {
     StringBuilder builder = new StringBuilder(query);
-    List<Rewrite> sortedRewrites = rewrites.stream()
-        .sorted(Comparator.comparing(rewrite -> rewrite.from))
-        .collect(Collectors.toList());
+    List<Rewrite> sortedRewrites =
+        rewrites.stream()
+            .sorted(Comparator.comparing(rewrite -> rewrite.from))
+            .collect(Collectors.toList());
 
     int rewritingOffset = 0;
     int previousRewriteTo = -1;
@@ -179,10 +176,12 @@ public class StatementRewriter {
   public static String quoteNamePaths(String query, ASTStatement parsedStatement) {
     List<Rewrite> rewrites =
         getResourcePathExpressionFromParseTree(parsedStatement).stream()
-            .map(pathExpression -> new Rewrite(
-                pathExpression.getParseLocationRange().start(),
-                pathExpression.getParseLocationRange().end(),
-                buildQuotedNamePath(pathExpression)))
+            .map(
+                pathExpression ->
+                    new Rewrite(
+                        pathExpression.getParseLocationRange().start(),
+                        pathExpression.getParseLocationRange().end(),
+                        buildQuotedNamePath(pathExpression)))
             .collect(Collectors.toList());
 
     return applyRewrites(query, rewrites);

--- a/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/StatementRewriterTest.java
+++ b/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/StatementRewriterTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.zetasql.LanguageOptions;
+import com.google.zetasql.Parser;
+import com.google.zetasql.parser.ASTNodes.ASTStatement;
+import com.google.zetasql.toolkit.StatementRewriter.Rewrite;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class StatementRewriterTest {
+
+  @Test
+  void testApplyRewrites() {
+    String original = "Greetings, Google!";
+    String expected = "Hello, World!";
+    List<Rewrite> rewrites = ImmutableList.of(
+        new Rewrite(0, 9, "Hello"),
+        new Rewrite(11, 17, "World")
+    );
+
+    String rewritten = StatementRewriter.applyRewrites(original, rewrites);
+    assertEquals(expected, rewritten);
+  }
+
+  @Test
+  void testQuoteNamePaths() {
+    String query = "SELECT * FROM `project.dataset`.`table`;";
+    String expectedRewritten = "SELECT * FROM `project.dataset.table`;";
+
+    ASTStatement parsedStatement = Parser.parseStatement(
+        query, new LanguageOptions().enableMaximumLanguageFeatures());
+    String rewritten = StatementRewriter.quoteNamePaths(query, parsedStatement);
+
+    assertEquals(expectedRewritten, rewritten);
+  }
+
+}

--- a/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/StatementRewriterTest.java
+++ b/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/StatementRewriterTest.java
@@ -32,10 +32,8 @@ public class StatementRewriterTest {
   void testApplyRewrites() {
     String original = "Greetings, Google!";
     String expected = "Hello, World!";
-    List<Rewrite> rewrites = ImmutableList.of(
-        new Rewrite(0, 9, "Hello"),
-        new Rewrite(11, 17, "World")
-    );
+    List<Rewrite> rewrites =
+        ImmutableList.of(new Rewrite(0, 9, "Hello"), new Rewrite(11, 17, "World"));
 
     String rewritten = StatementRewriter.applyRewrites(original, rewrites);
     assertEquals(expected, rewritten);
@@ -46,11 +44,10 @@ public class StatementRewriterTest {
     String query = "SELECT * FROM `project.dataset`.`table`;";
     String expectedRewritten = "SELECT * FROM `project.dataset.table`;";
 
-    ASTStatement parsedStatement = Parser.parseStatement(
-        query, new LanguageOptions().enableMaximumLanguageFeatures());
+    ASTStatement parsedStatement =
+        Parser.parseStatement(query, new LanguageOptions().enableMaximumLanguageFeatures());
     String rewritten = StatementRewriter.quoteNamePaths(query, parsedStatement);
 
     assertEquals(expectedRewritten, rewritten);
   }
-
 }

--- a/zetasql-toolkit-examples/README.md
+++ b/zetasql-toolkit-examples/README.md
@@ -14,8 +14,8 @@
 You can package an example into a container
 using [Jib](https://cloud.google.com/java/getting-started/jib).
 
-`mvn clean packge jib:build -DskipTests -Dcontainer.mainClass=MAIN_CLASS`
+`mvn -Prelease clean package jib:build -Dcontainer.mainClass=MAIN_CLASS`
 
 Example:
 
-`mvn -Prelease package jib:dockerBuild -Dcontainer.mainClass=com.google.zetasql.toolkit.examples.AnalyzeWithoutCatalog`
+`mvn -Prelease clean package jib:dockerBuild -Dcontainer.mainClass=com.google.zetasql.toolkit.examples.AnalyzeWithoutCatalog`

--- a/zetasql-toolkit-examples/README.md
+++ b/zetasql-toolkit-examples/README.md
@@ -18,4 +18,4 @@ using [Jib](https://cloud.google.com/java/getting-started/jib).
 
 Example:
 
-`mvn package jib:dockerBuild -DskipTests -Dcontainer.mainClass=com.google.zetasql.toolkit.examples.AnalyzeWithoutCatalog`
+`mvn -Prelease package jib:dockerBuild -Dcontainer.mainClass=com.google.zetasql.toolkit.examples.AnalyzeWithoutCatalog`

--- a/zetasql-toolkit-examples/pom.xml
+++ b/zetasql-toolkit-examples/pom.xml
@@ -58,8 +58,8 @@
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>${google.cloud.jib.version}</version>
         <configuration>
+          <skip>false</skip>
           <container>
             <mainClass>${container.mainClass}</mainClass>
             <expandClasspathDependencies>true</expandClasspathDependencies>

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/ShardedTableMigration.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/ShardedTableMigration.java
@@ -3,11 +3,10 @@ package com.google.zetasql.toolkit.examples;
 import com.google.common.collect.ImmutableMap;
 import com.google.zetasql.SqlFormatter;
 import com.google.zetasql.toolkit.tools.migration.ShardedTableMigrator;
-import java.text.ParseException;
 
 public class ShardedTableMigration {
 
-  public static void main(String[] args) throws ParseException {
+  public static void main(String[] args) {
     String query =
         "SELECT * FROM `project.dataset.table_202405*` "
             + "WHERE _TABLE_SUFFIX > '01' AND _TABLE_SUFFIX < '10';";

--- a/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/ShardedTableMigration.java
+++ b/zetasql-toolkit-examples/src/main/java/com/google/zetasql/toolkit/examples/ShardedTableMigration.java
@@ -1,0 +1,23 @@
+package com.google.zetasql.toolkit.examples;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.zetasql.SqlFormatter;
+import com.google.zetasql.toolkit.tools.migration.ShardedTableMigrator;
+import java.text.ParseException;
+
+public class ShardedTableMigration {
+
+  public static void main(String[] args) throws ParseException {
+    String query =
+        "SELECT * FROM `project.dataset.table_202405*` "
+            + "WHERE _TABLE_SUFFIX > '01' AND _TABLE_SUFFIX < '10';";
+    String projectId = "project";
+    ImmutableMap<String, String> tablesToPartitionColumns =
+        ImmutableMap.<String, String>builder()
+            .put("project.dataset.table", "PARTITION_COLUMN_NAME")
+            .build();
+    String result = ShardedTableMigrator.migrate(query, projectId, tablesToPartitionColumns);
+    String formatted = new SqlFormatter().lenientFormatSql(result);
+    System.out.println(formatted);
+  }
+}


### PR DESCRIPTION
Adds the `ShardedTableMigrator` tool under `com.google.zetasql.toolkit.tools.migration`.

The tool helps migrating BigQuery jobs away from date-sharded tables to partitioned tables. It automatically rewrites queries that use table wildcards and _TABLE_SUFFIX to use the new partitioned tables. Only SELECT statements and expressions are currently rewritten.